### PR TITLE
[nifi-registry] Removing the hard coded values as per the best practices

### DIFF
--- a/dysnix/nifi-registry/templates/statefulset.yaml
+++ b/dysnix/nifi-registry/templates/statefulset.yaml
@@ -29,7 +29,7 @@ spec:
       initContainers:
         {{- if .Values.flowProvider.git.enabled }}
         - name: git-clone
-          image: alpine/git:v2.26.2
+          image: "{{ .Values.initContainers.git.image }}:{{ .Values.initContainers.git.tag }}"
           command:
             - sh
             - -cex
@@ -61,7 +61,7 @@ spec:
         {{- end }}
         {{- if .Values.persistence.enabled }}
         - name: take-data-dir-ownership
-          image: alpine:3.6
+          image: "{{ .Values.initContainers.alpine.image }}:{{ .Values.initContainers.alpine.tag }}"
           command:
           command:
             - chown

--- a/dysnix/nifi-registry/templates/tests/test-connection.yaml
+++ b/dysnix/nifi-registry/templates/tests/test-connection.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   containers:
     - name: wget
-      image: busybox
+      image: "{{ .Values.tests.images.busybox.image }}:{{ .Values.tests.images.busybox.tag }}" 
       command: ['wget']
       args: ['{{ include "nifi-registry.fullname" . }}:{{ .Values.service.port }}/nifi-registry']
   restartPolicy: Never

--- a/dysnix/nifi-registry/values.yaml
+++ b/dysnix/nifi-registry/values.yaml
@@ -9,6 +9,16 @@ image:
   pullPolicy: IfNotPresent
   tag: "0.8.0"
 
+initContainers:
+  git:
+    image: alpine/git
+    tag: v2.26.2
+  alpine:
+    image: alpine
+    tag: 3.6
+
+
+
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
@@ -131,3 +141,9 @@ ssh:
   #   Hostname ssh.github.com
   #   Port 443
   #   IdentityFile /etc/fluxd/ssh/identity
+
+tests:
+  images:
+    busybox:
+      image: busybox
+      tag: 1.33.1


### PR DESCRIPTION
At present, the image values are hardcoded and cannot be modified. 
This is also a blocker when security policies are enforced for trusted registries.
