### PR TITLE
add extraenvs option for initcontainers

### DIFF
--- a/dysnix/nifi-registry/Chart.yaml
+++ b/dysnix/nifi-registry/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.1
+version: 0.3.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/dysnix/nifi-registry/templates/statefulset.yaml
+++ b/dysnix/nifi-registry/templates/statefulset.yaml
@@ -45,6 +45,9 @@ spec:
               value: {{ .Values.flowProvider.git.user }}          
             - name: NIFI_REGISTRY_GIT_PASSWORD
               value: {{ .Values.flowProvider.git.password }}
+          {{- if .Values.initContainers.extraEnvs }}
+{{ toYaml .Values.initContainers.extraEnvs | indent 12 }}
+          {{- end }}
           volumeMounts:
             - name: "flow-storage"
               mountPath: /tmp

--- a/dysnix/nifi-registry/values.yaml
+++ b/dysnix/nifi-registry/values.yaml
@@ -16,6 +16,11 @@ initContainers:
   alpine:
     image: alpine
     tag: 3.6
+  # Additional environment variables to set for the initContainers
+  extraEnvs: []
+  # extraEnvs:
+  #   - name: FOO
+  #     value: bar
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
This will allow to pass additional environment variables to the initcontainers. In our case we use it to set the `GIT_SSH_COMMAND` environment variable in the `git-clone` initcontainer.