### PR TITLE
Remove topology keys

### DIFF
--- a/dysnix/proxysql/Chart.yaml
+++ b/dysnix/proxysql/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "2.2.0"
 description: ProxySQL Helm chart for Kubernetes
 name: proxysql
-version: 0.3.0
+version: 0.3.1
 home: https://www.proxysql.com/
 sources:
   - https://github.com/dysnix/charts

--- a/dysnix/proxysql/templates/service.yaml
+++ b/dysnix/proxysql/templates/service.yaml
@@ -35,7 +35,6 @@ spec:
       {{- if .Values.service.adminNodePort }}
       nodePort: {{ .Values.service.adminNodePort }}
       {{- end }}
-  topologyKeys:
   selector:
     app: {{ include "proxysql.name" . }}
     release: {{ .Release.Name }}

--- a/dysnix/proxysql/templates/service.yaml
+++ b/dysnix/proxysql/templates/service.yaml
@@ -36,13 +36,6 @@ spec:
       nodePort: {{ .Values.service.adminNodePort }}
       {{- end }}
   topologyKeys:
-    {{- /*
-      Service prefers node local, zonal, then regional endpoints but falls back to cluster wide endpoints.
-    */}}
-    - "kubernetes.io/hostname"
-    - "topology.kubernetes.io/zone"
-    - "topology.kubernetes.io/region"
-    - "*"
   selector:
     app: {{ include "proxysql.name" . }}
     release: {{ .Release.Name }}
@@ -67,14 +60,6 @@ spec:
       nodePort: {{ .Values.service.adminNodePort }}
       {{- end }}
   clusterIP: None
-  topologyKeys:
-    {{- /*
-      Service prefers node local, zonal, then regional endpoints but falls back to cluster wide endpoints.
-    */}}
-    - "kubernetes.io/hostname"
-    - "topology.kubernetes.io/zone"
-    - "topology.kubernetes.io/region"
-    - "*"
   selector:
     app: {{ include "proxysql.name" . }}-core
     release: {{ .Release.Name }}


### PR DESCRIPTION
Removing topologyKeys from the service.yaml template as it was deprecated from Kubernetes v1.21 and bumped the chart version.