### PR TITLE
NiFi Registry JGit SSH client fails if /home/nifi/.ssh is not writable

### DIFF
--- a/dysnix/nifi-registry/Chart.yaml
+++ b/dysnix/nifi-registry/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.6
+version: 0.3.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/dysnix/nifi-registry/Chart.yaml
+++ b/dysnix/nifi-registry/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.5
+version: 0.3.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/dysnix/nifi-registry/templates/statefulset.yaml
+++ b/dysnix/nifi-registry/templates/statefulset.yaml
@@ -46,13 +46,13 @@ spec:
             - name: NIFI_REGISTRY_GIT_PASSWORD
               value: {{ .Values.flowProvider.git.password }}
           {{- if .Values.initContainers.extraEnvs }}
-            {{ toYaml .Values.initContainers.extraEnvs | indent 12 }}
+            {{ toYaml .Values.initContainers.extraEnvs | nindent 12 }}
           {{- end }}
           volumeMounts:
             - name: "flow-storage"
               mountPath: /tmp
             {{- if .Values.ssh.known_hosts }}
-            - name: sshdir
+            - name: sshcfgmap
               mountPath: /root/.ssh
               readOnly: true
             {{- end }}
@@ -95,6 +95,11 @@ spec:
               cd postgresql
               curl -k "{{ .Values.flowProvider.postgres.driverURL }}{{ .Values.flowProvider.postgres.fileName }}" -o "{{ .Values.flowProvider.postgres.fileName }}"
             {{- end }}
+            {{- if .Values.ssh.known_hosts }}
+              cp --verbose --dereference /sshcfgmap/known_hosts /home/nifi/.ssh/
+              cp --verbose --dereference --force /sshcfgmap/config /home/nifi/.ssh/
+              cp --verbose --dereference --force /ssh/id_rsa /home/nifi/.ssh/
+            {{- end }}
               ${NIFI_REGISTRY_BASE_DIR}/scripts/start.sh
           ports:
             - name: http
@@ -126,7 +131,7 @@ spec:
               value: {{ .Values.flowProvider.postgres.password }}
           {{- end }}
           {{- if .Values.extraEnvs }}
-            {{ toYaml .Values.extraEnvs | indent 12 }}
+            {{ toYaml .Values.extraEnvs | nindent 12 }}
           {{- end }}
           volumeMounts:
             {{ if .Values.persistence.enabled }}
@@ -139,9 +144,12 @@ spec:
               subPath: flow_storage
             {{ end }}
             {{- if .Values.ssh.known_hosts }}
+            - name: sshcfgmap
+              mountPath: /sshcfgmap
+              readOnly: true
             - name: sshdir
               mountPath: /home/nifi/.ssh
-              readOnly: true
+              readOnly: false
             {{- end }}
             {{- if .Values.flowProvider.git.enabled }}
             {{- if .Values.flowProvider.git.config.enabled }}
@@ -167,6 +175,8 @@ spec:
       volumes:
         {{- if .Values.ssh.known_hosts }}
         - name: sshdir
+          emptyDir: {}
+        - name: sshcfgmap
           configMap:
             name: {{ template "nifi-registry.fullname" . }}-ssh-config
             defaultMode: 0644

--- a/dysnix/nifi-registry/templates/statefulset.yaml
+++ b/dysnix/nifi-registry/templates/statefulset.yaml
@@ -97,8 +97,12 @@ spec:
             {{- end }}
             {{- if .Values.ssh.known_hosts }}
               cp --verbose --dereference /sshcfgmap/known_hosts /home/nifi/.ssh/
-              cp --verbose --dereference --force /sshcfgmap/config /home/nifi/.ssh/
-              cp --verbose --dereference --force /ssh/id_rsa /home/nifi/.ssh/
+              {{- if .Values.ssh.config }}
+                cp --verbose --dereference /sshcfgmap/config /home/nifi/.ssh/
+              {{- end }}
+              {{- if .Values.flowProvider.git.enabled }}
+                cp --verbose --dereference /ssh/id_rsa /home/nifi/.ssh/
+              {{- end }}
             {{- end }}
               ${NIFI_REGISTRY_BASE_DIR}/scripts/start.sh
           ports:

--- a/dysnix/nifi-registry/values.yaml
+++ b/dysnix/nifi-registry/values.yaml
@@ -104,14 +104,14 @@ flowProvider:
     user:
     password:
     # The secret name can be used to supply your own SSH key:
-    # 1. Generate a SSH key named identity:
-    #      ssh-keygen -q -N "" -f ./identity
+    # 1. Generate a SSH key named id_rsa:
+    #      ssh-keygen -q -N "" -f ./id_rsa
     # 2. Create a Kubernetes secret:
-    #      kubectl -n nifi-registry create secret generic nifi-registry-git-deploy --from-file=./identity
+    #      kubectl -n nifi-registry create secret generic nifi-registry-git-deploy --from-file=./id_rsa
     # 3. Don't check these key files into your Git repository! Once you've created
     #    the Kubernetes secret, Delete the private key:
-    #      rm ./identity
-    # 4. Add ./identity.pub as a deployment key with write access in your Git repo
+    #      rm ./id_rsa
+    # 4. Add ./id_rsa.pub as a deployment key with write access in your Git repo
     # 5. Set the secret name (default: nifi-registry-git-deploy) below
     secretName:
     # Global Git configuration See https://git-scm.com/docs/git-config for more details.


### PR DESCRIPTION
If /home/nifi/.ssh is not writable, JGit can't create a known_hosts.lock file and throws an exception.  This makes it impossible for NiFi Registry to check in a commit to a Git repository via SSH, and leaves NiFi in a state where there is no checked-in revision of a process group.

Also, extraEnvs was broken because indent was being used instead of nindent.

Finally, the values.yaml comments show creating an SSH private key named identity, but the chart actually expects the private key to be named id_rsa.