### PR TITLE
[bsc] add CloneSet support, various fixes and improvements

### DIFF
--- a/dysnix/bsc/Chart.yaml
+++ b/dysnix/bsc/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: bsc
 description: Binance Smart Chain chart for Kubernetes
-version: "0.4.25"
-appVersion: "v1.1.6"
+version: "0.5.0"
+appVersion: "v1.1.7"
 
 keywords:
   - geth

--- a/dysnix/bsc/templates/_helpers.tpl
+++ b/dysnix/bsc/templates/_helpers.tpl
@@ -43,3 +43,14 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "bsc.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "bsc.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/dysnix/bsc/templates/configmap.yaml
+++ b/dysnix/bsc/templates/configmap.yaml
@@ -42,6 +42,10 @@ data:
     {{- include (print $.Template.BasePath "/scripts/_check_node_readiness.tpl") . | nindent 4 }}
   get_nodekey.py: |-
     {{- include (print $.Template.BasePath "/scripts/_get_nodekey.tpl") . | nindent 4 }}
+  get_nodekey_ip.py: |-
+    {{- include (print $.Template.BasePath "/scripts/_get_nodekey_ip.tpl") . | nindent 4 }}
+  generate_node_config.sh: |-
+    {{- include (print $.Template.BasePath "/scripts/_generate_node_config.tpl") . | nindent 4 }}
   init_from_snaphot.sh: |-
   {{- include (print $.Template.BasePath "/scripts/_init_from_snaphot.tpl") . | nindent 4 }}
   init_from_rsync.sh: |-

--- a/dysnix/bsc/templates/configs/_config.txt
+++ b/dysnix/bsc/templates/configs/_config.txt
@@ -47,6 +47,18 @@ WSPort = {{ .Values.service.wsPort }}
 WSOrigins = ["*"]
 WSModules = ["net", "web3", "eth"]
 
+[Node.HTTPTimeouts]
+ReadTimeout = 30000000000
+WriteTimeout = 30000000000
+IdleTimeout = 120000000000
+
+[Node.LogConfig]
+FilePath = "bsc.log"
+MaxBytesSize = 10485760
+Level = "info"
+FileRoot = ""
+
+# keep this section the last one, as we may append trusted nodes via config generation
 [Node.P2P]
 EnableMsgEvents = false
 MaxPeers = {{ .Values.bsc.maxpeers }}
@@ -61,14 +73,3 @@ StaticNodes = ["{{ join "\",\"" .Values.bsc.staticNodes }}"]
 {{- if .Values.bsc.trustedNodes }}
 TrustedNodes = ["{{ join "\",\"" .Values.bsc.trustedNodes }}"]
 {{- end }}
-
-[Node.HTTPTimeouts]
-ReadTimeout = 30000000000
-WriteTimeout = 30000000000
-IdleTimeout = 120000000000
-
-[Node.LogConfig]
-FilePath = "bsc.log"
-MaxBytesSize = 10485760
-Level = "info"
-FileRoot = ""

--- a/dysnix/bsc/templates/configs/_nginx.txt
+++ b/dysnix/bsc/templates/configs/_nginx.txt
@@ -32,7 +32,11 @@ http {
     }
 
     upstream bsc {
+        {{- if and .Values.nginx.overrideBackendAddress .Values.nginx.backendAddress }}
+        server {{ .Values.nginx.backendAddress }} max_fails=0;
+        {{- else }}
         server {{ .Release.Name }}:{{ .Values.service.rpcPort }} max_fails=0;
+        {{- end }}
         keepalive 16;
     }
 

--- a/dysnix/bsc/templates/scripts/_generate_node_config.tpl
+++ b/dysnix/bsc/templates/scripts/_generate_node_config.tpl
@@ -1,0 +1,39 @@
+#!/usr/bin/env sh
+
+set -ex # -e exits on error
+SRC_DIR=/config
+DST_DIR=/generated-config
+CONFIG_NAME=config.toml
+TRUSTED_NODES_SRC_URL={{ .Values.bsc.trustedNodesSrcUrl }}
+NODEKEYS_SRC_URL={{ .Values.bsc.nodekeysSrcUrl }}
+NODEKEYS={{ .Values.bsc.nodekeysFileName }}
+TRUSTED_NODES=trusted_nodes
+
+{{ if and (eq .Values.controller "CloneSet") .Values.bsc.getNodeKey }}
+gsutil cp "${NODEKEYS_SRC_URL}" "${DST_DIR}/${NODEKEYS}"
+{{- end }}
+
+# check if we really need to generate config
+if [ "${GENERATE_CONFIG}" != "true" ];then
+  echo "Config generation disabled, copying instead"
+  cp -f "${SRC_DIR}/${CONFIG_NAME}" "${DST_DIR}/${CONFIG_NAME}"
+  exit 0
+fi
+
+# config generation
+cd /tmp
+
+gsutil cp "${TRUSTED_NODES_SRC_URL}" "${TRUSTED_NODES}"
+
+# # https://askubuntu.com/a/1175271
+# # replace a matching line with a file content
+# sed  -e "/^TrustedNodes.*/{r${TRUSTED_NODES}" -e "d}" "${SRC_DIR}/${CONFIG_NAME}" > "${DST_DIR}/${CONFIG_NAME}"
+#
+# if [ -s "${DST_DIR}/${CONFIG_NAME}" ];then
+#   echo "Resulting config is empty"
+#   exit 1
+# fi
+
+cp "${SRC_DIR}/${CONFIG_NAME}" "${DST_DIR}/${CONFIG_NAME}"
+echo >> "${DST_DIR}/${CONFIG_NAME}"
+cat "${TRUSTED_NODES}" >> "${DST_DIR}/${CONFIG_NAME}"

--- a/dysnix/bsc/templates/scripts/_get_nodekey_ip.tpl
+++ b/dysnix/bsc/templates/scripts/_get_nodekey_ip.tpl
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+import os
+import sys
+import ipaddress
+import json
+
+nodeKeysFileName = "/generated-config/{{ .Values.bsc.nodekeysFileName }}"
+
+def get_nodekey(nodeKeysFileName):
+    addr=ipaddress.ip_address(os.environ['MY_POD_IP'])
+    net=ipaddress.ip_network("{{ .Values.bsc.podRange }}")
+    if addr in net:
+      node_id=int(addr)-int(net[0])
+    else:
+      sys.stdout.write("Pod address "+str(addr)+" in not inside network "+str(net))
+      sys.exit(1)
+    with open(nodeKeysFileName, "r") as f:
+      KEYS=json.load(f)
+      return KEYS[node_id]
+
+if __name__ == '__main__':
+    nodekey = get_nodekey(nodeKeysFileName)
+    with open("{{ .Values.bsc.base_path }}/geth/nodekey", "w") as f:
+        sys.stdout.write("Node key: {}".format(nodekey))
+        f.write(nodekey)

--- a/dysnix/bsc/templates/scripts/_init_from_snaphot.tpl
+++ b/dysnix/bsc/templates/scripts/_init_from_snaphot.tpl
@@ -20,7 +20,7 @@ rm -rf ${DATA_DIR}/geth
 # Download & extract snapshot
 # special handling of zstd
 if [[ "${SNAPSHOT_URL}" =~ "\.zst$" ]]; then
-  wget ${SNAPSHOT_URL} -O - | tar --zstd --overwrite -x -C ${DATA_DIR}
+  wget ${SNAPSHOT_URL} -O - | mbuffer -m5% -q -l /tmp/m1.log | zstd -d -T0 | mbuffer -m5% -q -l /tmp/m2.log | tar --overwrite -x -C ${DATA_DIR}
 else
   wget ${SNAPSHOT_URL} -O - | tar --overwrite -x -C ${DATA_DIR}
 fi

--- a/dysnix/bsc/templates/serviceaccount.yaml
+++ b/dysnix/bsc/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "bsc.serviceAccountName" . }}
+  labels:
+    {{- include "bsc.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/dysnix/bsc/templates/statefulset.yaml
+++ b/dysnix/bsc/templates/statefulset.yaml
@@ -1,15 +1,28 @@
+{{- if eq .Values.controller "StatefulSet" }}
 apiVersion: apps/v1
 kind: StatefulSet
+{{- end }}
+{{- if eq .Values.controller "CloneSet" }}
+apiVersion: apps.kruise.io/v1alpha1
+kind: CloneSet
+{{- end }}
 metadata:
   name: {{ include "bsc.fullname" . }}
   labels:
 {{ include "bsc.labels" . | indent 4 }}
 spec:
-  serviceName: "{{ .Release.Name }}-service"
   replicas: {{ .Values.replicaCount }} # by default is 1
   updateStrategy:
     {{- toYaml .Values.updateStrategy | nindent 4 }}
+  {{- if eq .Values.controller "StatefulSet" }}
+  serviceName: "{{ .Release.Name }}-service"
   podManagementPolicy: {{ .Values.podManagementPolicy }}
+  {{- end }}
+  {{- if eq .Values.controller "CloneSet" }}
+  minReadySeconds: {{ .Values.minReadySeconds }}
+  scaleStrategy:
+    {{- toYaml .Values.scaleStrategy | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "bsc.name" . }}
@@ -24,7 +37,11 @@ spec:
         manualstatus: {{ .Values.bsc.manualStatus }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if eq .Values.controller "CloneSet" }}
+        controller.kubernetes.io/pod-deletion-cost: {{ .Values.podDeletionCost | quote }}
+        {{- end }}
     spec:
+      serviceAccountName: {{ include "bsc.serviceAccountName" . }}
       {{- with .Values.securityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
@@ -97,7 +114,7 @@ spec:
           protocol: {{ $val.protocol | default "TCP" }}
           {{- end }}
         volumeMounts:
-        - name: bsc-config
+        - name: generated-bsc-config
           mountPath: /config
         - name: scripts
           mountPath: /scripts
@@ -259,11 +276,42 @@ spec:
         volumeMounts:
           - name: bsc-pvc
             mountPath: {{ .Values.bsc.base_path }}
-      {{- if .Values.bsc.getNodeKey }}
+      - name: generate-bsc-config
+        command:
+          - sh
+          - /scripts/generate_node_config.sh
+        env:
+          - name: GENERATE_CONFIG
+            value: {{ .Values.bsc.generateConfig | quote }}
+          - name: HOME
+            value: "/tmp"
+        image: google/cloud-sdk:alpine
+        imagePullPolicy: IfNotPresent
+        volumeMounts:
+          - name: bsc-config
+            mountPath: /config
+          - name: generated-bsc-config
+            mountPath: /generated-config
+          - name: scripts
+            mountPath: /scripts
+
+        {{- if .Values.bsc.getNodeKey }}
       - name: get-nodekey
+        {{- if eq .Values.controller "StatefulSet" }}
         command:
           - python
           - /scripts/get_nodekey.py
+        {{ end }}
+        {{- if eq .Values.controller "CloneSet" }}
+        command:
+          - python
+          - /scripts/get_nodekey_ip.py
+        {{ end }}
+        env:
+          - name: MY_POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
         image: python:slim
         imagePullPolicy: IfNotPresent
         volumeMounts:
@@ -271,6 +319,8 @@ spec:
             mountPath: {{ .Values.bsc.base_path }}
           - name: scripts
             mountPath: /scripts
+          - name: generated-bsc-config
+            mountPath: /generated-config
       {{- end }}
       {{- if .Values.bsc.staticNodeKey }}
       - name: set-nodekey
@@ -288,6 +338,8 @@ spec:
         - name: bsc-config
           configMap:
             name: "{{ .Release.Name }}-config"
+        - name: generated-bsc-config
+          emptyDir: {}
         {{- if .Values.rsyncd.enabled }}
         - name: rsyncd-config
           configMap:
@@ -311,7 +363,6 @@ spec:
   {{- if .Values.persistence.enabled }}
   volumeClaimTemplates:
     - metadata:
-        creationTimestamp: null
         name: bsc-pvc
         labels:
           app: bsc

--- a/dysnix/bsc/values.yaml
+++ b/dysnix/bsc/values.yaml
@@ -14,12 +14,48 @@ image:
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+# possible values:  StatefulSet CloneSet
+controller: StatefulSet
+
+# StatefulSet-specific options
 podManagementPolicy: OrderedReady
+
+# CloneSet-specific options
+minReadySeconds: 60
+scaleStrategy: {}
+# scaleStrategy:
+#  # scale up limit rate
+#  maxUnavailable: 1
+#  # selective pod deletion
+#   podsToDelete:
+#     - sample-9m4hp
+#
+# common options, default os for StatefulSet
 updateStrategy:
   type: RollingUpdate
 
-continent:
+# CloneSet options example
+# updateStrategy:
+#   type: InPlaceOnly
+#   inPlaceUpdateStrategy:
+#     gracePeriodSeconds: 10
+#   partitions: 3
+#   maxUnavailable: 20%
+#   maxSurge: 3
+# .... a lot more, check https://openkruise.io/docs/user-manuals/cloneset/#update-types
+podDeletionCost: 0
 
+continent:
 # Don't use spaces or special chars
 bsc:
   # we don't have other chains, it's just a pod label for now
@@ -44,12 +80,17 @@ bsc:
   noDiscovery: false
   initGenesis: false
   initFromSnapshot: false
-  initFromSnapshotImage: dysnix/alpine-zstd:3.15
+  initFromSnapshotImage: dysnix/zstd:v3.15.1
   initFromRsync: false
   initFromRsyncImage: instrumentisto/rsync-ssh:latest
   forceInitFromSnapshot: false
   snapshotUrl:
   snapshotRsyncUrl: "rsync://192.168.8.4/snapshot/geth/node/geth"
+  podRange: 192.168.0.0/20
+  generateConfig: false
+  trustedNodesSrcUrl: "gs://bucket/trusted_nodes"
+  nodekeysSrcUrl: "gs://bucket/nodekeys"
+  nodekeysFileName: "nodekeys"
   getNodeKey: false
   staticNodeKey: false
 
@@ -163,6 +204,9 @@ rsyncd:
     port: 1873
     name: rsyncd
 
+nginx:
+  overrideBackendAddress: false
+  backendAddress:
 failback:
   enabled: false
   image:


### PR DESCRIPTION
* add [CloneSet](https://openkruise.io/docs/user-manuals/cloneset) support to handle custom scale-up/scale-down
  * add nodekey pick-up script based on pod's IP address, no other options with CloneSet
  * allow trusted nodes list download from GCS to handle long lists, no other options with CloneSet
    * minor BSC node config changes to simple file concatenation
* add nginx backend override variable
* add service account and use it in controller
* add mbuffer to the pipeline with zstd-compressed archive to speedup things