### PR TITLE
[bsc] GCS init/sync, prune, various improvements

### DIFF
--- a/dysnix/bsc/Chart.yaml
+++ b/dysnix/bsc/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: bsc
 description: Binance Smart Chain chart for Kubernetes
-version: "0.5.1"
+version: "0.6.0"
 appVersion: "v1.1.7"
 
 keywords:

--- a/dysnix/bsc/templates/alerts.yaml
+++ b/dysnix/bsc/templates/alerts.yaml
@@ -2,8 +2,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
-  labels:
-{{ include "bsc.labels" . | indent 4 }}
+  labels: {{ include "bsc.labels" . | nindent 4 }}
   name: {{ include "bsc.fullname" . }}.rules
 spec:
   groups:

--- a/dysnix/bsc/templates/backendconfig.yaml
+++ b/dysnix/bsc/templates/backendconfig.yaml
@@ -3,8 +3,7 @@ apiVersion: cloud.google.com/v1
 kind: BackendConfig
 metadata:
   name: {{ .Release.Name }}
-  labels:
-{{ include "bsc.labels" . | indent 4 }}
+  labels: {{ include "bsc.labels" . | nindent 4 }}
 spec:
   {{- toYaml .Values.multicluster.backend | nindent 2 }}
 {{- end }}

--- a/dysnix/bsc/templates/configmap.yaml
+++ b/dysnix/bsc/templates/configmap.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: "{{ .Release.Name }}-config"
+  labels: {{ include "bsc.labels" . | nindent 4 }}
 data:
   config.toml: |-
   {{- include (print $.Template.BasePath "/configs/_config.txt") . | nindent 4 }}
@@ -11,6 +12,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: "{{ .Release.Name }}-rsyncd-config"
+  labels: {{ include "bsc.labels" . | nindent 4 }}
 data:
   rsyncd.conf: |-
   {{- include (print $.Template.BasePath "/configs/_rsyncd.txt") . | nindent 4 }}
@@ -20,6 +22,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: "{{ .Release.Name }}-env"
+  labels: {{ include "bsc.labels" . | nindent 4 }}
 data:
   {{- include (print $.Template.BasePath "/configs/_env.txt") . | nindent 2 }}
 ---
@@ -27,6 +30,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: "{{ .Release.Name }}-probe-env"
+  labels: {{ include "bsc.labels" . | nindent 4 }}
 data:
   env.txt: |-
   {{- include (print $.Template.BasePath "/configs/_probe-env.txt") . | nindent 4 }}
@@ -35,6 +39,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: "{{ .Release.Name }}-scripts"
+  labels: {{ include "bsc.labels" . | nindent 4 }}
 data:
   check_node_health.sh: |-
     {{- include (print $.Template.BasePath "/scripts/_check_node_health.tpl") . | nindent 4 }}
@@ -56,6 +61,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: "{{ .Release.Name }}-nginx-config"
+  labels: {{ include "bsc.labels" . | nindent 4 }}
 data:
   nginx.conf: |-
   {{- include (print $.Template.BasePath "/configs/_nginx.txt") . | nindent 4 }}

--- a/dysnix/bsc/templates/configmap.yaml
+++ b/dysnix/bsc/templates/configmap.yaml
@@ -52,7 +52,7 @@ data:
   generate_node_config.sh: |-
     {{- include (print $.Template.BasePath "/scripts/_generate_node_config.tpl") . | nindent 4 }}
   init_from_snaphot.sh: |-
-  {{- include (print $.Template.BasePath "/scripts/_init_from_snaphot.tpl") . | nindent 4 }}
+    {{- include (print $.Template.BasePath "/scripts/_init_from_snaphot.tpl") . | nindent 4 }}
   init_from_rsync.sh: |-
   {{- include (print $.Template.BasePath "/scripts/_init_from_rsync.tpl") . | nindent 4 }}
 ---

--- a/dysnix/bsc/templates/configmap.yaml
+++ b/dysnix/bsc/templates/configmap.yaml
@@ -54,7 +54,17 @@ data:
   init_from_snaphot.sh: |-
     {{- include (print $.Template.BasePath "/scripts/_init_from_snaphot.tpl") . | nindent 4 }}
   init_from_rsync.sh: |-
-  {{- include (print $.Template.BasePath "/scripts/_init_from_rsync.tpl") . | nindent 4 }}
+    {{- include (print $.Template.BasePath "/scripts/_init_from_rsync.tpl") . | nindent 4 }}
+  init_from_gcs.sh: |-
+    {{- include (print $.Template.BasePath "/scripts/_init_from_gcs.tpl") . | nindent 4 }}
+  sync_to_gcs.sh: |-
+    {{- include (print $.Template.BasePath "/scripts/_sync_to_gcs.tpl") . | nindent 4 }}
+  gcs_cleanup.sh: |-
+    {{- include (print $.Template.BasePath "/scripts/_gcs_cleanup.tpl") . | nindent 4 }}
+  prune.sh: |-
+    {{- include (print $.Template.BasePath "/scripts/_prune.tpl") . | nindent 4 }}
+  cron.sh: |-
+    {{- include (print $.Template.BasePath "/scripts/_cron.tpl") . | nindent 4 }}
 ---
 {{- if .Values.failback.enabled }}
 apiVersion: v1

--- a/dysnix/bsc/templates/cronjob-rbac.yaml
+++ b/dysnix/bsc/templates/cronjob-rbac.yaml
@@ -1,0 +1,44 @@
+{{- if or .Values.cronjobs.sync.enabled .Values.cronjobs.prune.enabled -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-cronjob
+  labels: {{ include "bsc.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Release.Name }}-cronjob
+rules:
+  - apiGroups: [""]
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+  - apiGroups: [""]
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}-cronjob
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-cronjob
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ .Release.Name }}-cronjob
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/dysnix/bsc/templates/cronjob-rbac.yaml
+++ b/dysnix/bsc/templates/cronjob-rbac.yaml
@@ -13,6 +13,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ .Release.Name }}-cronjob
+  labels: {{ include "bsc.labels" . | nindent 4 }}
 rules:
   - apiGroups: [""]
     resources:
@@ -33,6 +34,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ .Release.Name }}-cronjob
+  labels: {{ include "bsc.labels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
     name: {{ .Release.Name }}-cronjob

--- a/dysnix/bsc/templates/cronjob.yaml
+++ b/dysnix/bsc/templates/cronjob.yaml
@@ -1,0 +1,125 @@
+{{- if .Values.cronjobs.sync.enabled }}
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: "{{ .Release.Name }}-sync"
+  labels: {{ include "bsc.labels" . | nindent 4 }}
+spec:
+  schedule: "{{ .Values.cronjobs.sync.schedule }}"
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 300
+  jobTemplate:
+    metadata:
+      name: "{{ .Release.Name }}-sync"
+    spec:
+      activeDeadlineSeconds: 60
+      backoffLimit: 0
+      template:
+        metadata:
+          labels: {{ include "bsc.labels" . | nindent 12 }}
+        spec:
+          containers:
+            - name: "sync"
+              image: "{{ .Values.cronjobs.sync.image }}"
+              command:
+                - /bin/sh
+                - /scripts/cron.sh
+                - sync
+                - 5s
+              imagePullPolicy: {{ .Values.image.pullPolicy }}
+              envFrom:
+                - configMapRef:
+                    name: "{{ .Release.Name }}-env"
+              resources:
+              {{- toYaml .Values.cronjobs.sync.resources | nindent 16 }}
+              volumeMounts:
+                - name: scripts
+                  mountPath: /scripts
+          volumes:
+            - name: scripts
+              configMap:
+                name: "{{ .Release.Name }}-scripts"
+          restartPolicy: Never
+          {{- with .Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          serviceAccountName: {{ .Release.Name }}-cronjob
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- with .Values.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.affinity }}
+          affinity:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+{{- end }}
+---
+{{- if .Values.cronjobs.prune.enabled }}
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: "{{ .Release.Name }}-prune"
+  labels: {{ include "bsc.labels" . | nindent 4 }}
+spec:
+  schedule: "{{ .Values.cronjobs.prune.schedule }}"
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 300
+  jobTemplate:
+    metadata:
+      name: "{{ .Release.Name }}-prune"
+    spec:
+      activeDeadlineSeconds: 900
+      backoffLimit: 0
+      template:
+        metadata:
+          labels: {{ include "bsc.labels" . | nindent 12 }}
+        spec:
+          containers:
+            - name: "prune"
+              image: "{{ .Values.cronjobs.prune.image }}"
+              command:
+                - /bin/sh
+                - /scripts/cron.sh
+                - prune
+                - 600s
+              imagePullPolicy: {{ .Values.image.pullPolicy }}
+              envFrom:
+                - configMapRef:
+                    name: "{{ .Release.Name }}-env"
+              resources:
+              {{- toYaml .Values.cronjobs.prune.resources | nindent 16 }}
+              volumeMounts:
+                - name: scripts
+                  mountPath: /scripts
+          volumes:
+            - name: scripts
+              configMap:
+                name: "{{ .Release.Name }}-scripts"
+          restartPolicy: Never
+          {{- with .Values.imagePullSecrets }}
+          imagePullSecrets:
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
+          serviceAccountName: {{ .Release.Name }}-cronjob
+          securityContext:
+          {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- with .Values.nodeSelector }}
+          nodeSelector:
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.affinity }}
+          affinity:
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.tolerations }}
+          tolerations:
+          {{- toYaml . | nindent 12 }}
+  {{- end }}
+{{- end }}

--- a/dysnix/bsc/templates/hpa.yaml
+++ b/dysnix/bsc/templates/hpa.yaml
@@ -4,6 +4,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: "{{ .Release.Name }}"
   namespace: "{{ .Release.Namespace }}"
+  labels: {{ include "bsc.labels" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/dysnix/bsc/templates/ilb.yaml
+++ b/dysnix/bsc/templates/ilb.yaml
@@ -5,9 +5,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Release.Name }}-ilb
-  labels:
-    chain: eth
-{{ include "bsc.labels" . | indent 4 }}
+  labels: {{ include "bsc.labels" . | nindent 4 }}
   annotations:
     cloud.google.com/load-balancer-type: "Internal"
     cloud.google.com/network-tier: "PREMIUM"

--- a/dysnix/bsc/templates/ingress.yaml
+++ b/dysnix/bsc/templates/ingress.yaml
@@ -4,8 +4,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}-jsonrpc
-  labels:
-{{ include "bsc.labels" . | indent 4 }}
+  labels: {{ include "bsc.labels" . | nindent 4 }}
   {{- with .Values.ingress.rpc.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/dysnix/bsc/templates/lb-p2p-discovery.yaml
+++ b/dysnix/bsc/templates/lb-p2p-discovery.yaml
@@ -4,9 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Release.Name }}-lb-p2p-discovery
-  labels:
-    chain: eth
-{{ include "bsc.labels" . | indent 4 }}
+  labels: {{ include "bsc.labels" . | nindent 4 }}
 spec:
   type: LoadBalancer
   {{ if .Values.externalLBp2pDiscoveryIP }}

--- a/dysnix/bsc/templates/lb-p2p.yaml
+++ b/dysnix/bsc/templates/lb-p2p.yaml
@@ -4,9 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Release.Name }}-lb-p2p
-  labels:
-    chain: eth
-{{ include "bsc.labels" . | indent 4 }}
+  labels: {{ include "bsc.labels" . | nindent 4 }}
 spec:
   type: LoadBalancer
   {{ if .Values.externalLBp2pIP }}

--- a/dysnix/bsc/templates/lb.yaml
+++ b/dysnix/bsc/templates/lb.yaml
@@ -5,9 +5,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Release.Name }}-lb
-  labels:
-    chain: eth
-{{ include "bsc.labels" . | indent 4 }}
+  labels: {{ include "bsc.labels" . | nindent 4 }}
 spec:
   type: LoadBalancer
   {{ if .Values.externalLBIP }}

--- a/dysnix/bsc/templates/mci.yaml
+++ b/dysnix/bsc/templates/mci.yaml
@@ -3,8 +3,7 @@ apiVersion: networking.gke.io/v1
 kind: MultiClusterIngress
 metadata:
   name: {{ .Release.Name }}
-  labels:
-{{ include "bsc.labels" . | indent 4 }}
+  labels: {{ include "bsc.labels" . | nindent 4 }}
   {{- if .Values.multicluster.ingress.ip }}
   annotations:
     networking.gke.io/static-ip: {{ .Values.multicluster.ingress.ip }}

--- a/dysnix/bsc/templates/mcs.yaml
+++ b/dysnix/bsc/templates/mcs.yaml
@@ -7,8 +7,7 @@ metadata:
   annotations:
     beta.cloud.google.com/backend-config: '{"ports": {"{{ .Values.multicluster.service.port }}":"{{ .Release.Name }}"}}'
   {{- end }}
-  labels:
-{{ include "bsc.labels" . | indent 4 }}
+  labels: {{ include "bsc.labels" . | nindent 4 }}
 spec:
   template:
     spec:

--- a/dysnix/bsc/templates/scripts/_cron.tpl
+++ b/dysnix/bsc/templates/scripts/_cron.tpl
@@ -1,0 +1,78 @@
+#!/usr/bin/env sh
+
+# possible values are
+# "sync" to trigger sync-to-gcs
+# "prune" to trigger prune
+MODE="${1}"
+POD_NAME={{ include "bsc.fullname" . }}-0
+CONFIGMAP_NAME="{{ .Release.Name }}-env"
+KUBECTL=$(which kubectl)
+# wait timeout, f.e "30s"
+WAIT_TIMEOUT="${2}"
+PATCH_DATA=""
+
+check_ret(){
+        ret="${1}"
+        msg="${2}"
+        # allow to override exit code, default value is ret
+        exit_code=${3:-${ret}}
+        if [ ! "${ret}" -eq 0 ];then
+                echo "${msg}"
+                echo "return code ${ret}, exit code ${exit_code}"
+                exit "${exit_code}"
+        fi
+}
+
+# input data checking
+[ "${MODE}" = "prune" ] || [ "${MODE}" = "sync" ]
+check_ret $? "$(date -Iseconds) Mode value \"${MODE}\" is incorrect, abort"
+
+# wait for pod to become ready
+echo "$(date -Iseconds) Waiting ${WAIT_TIMEOUT} for pod ${POD_NAME} to become ready ..."
+${KUBECTL} wait --timeout="${WAIT_TIMEOUT}" --for=condition=Ready pod "${POD_NAME}"
+ret=$?
+# exit code override to "success"
+check_ret "${ret}" "$(date -Iseconds) Pod ${POD_NAME} is not ready, nothing to do, exiting" 0
+
+# ensuring pod is not terminating now
+# https://github.com/kubernetes/kubernetes/issues/22839
+echo "$(date -Iseconds) Checking for pod ${POD_NAME} to not terminate ..."
+DELETION_TIMESTAMP=$(${KUBECTL} get -o jsonpath='{.metadata.deletionTimestamp}' pod "${POD_NAME}")
+ret=$?
+check_ret "${ret}" "$(date -Iseconds) Cannot get pod ${POD_NAME}, abort"
+
+# empty timestamp means that pod is not terminating now
+if [ "${DELETION_TIMESTAMP}" = "" ];then
+  # we're good to go
+  echo "$(date -Iseconds) Pod ${POD_NAME} is ready, continuing"
+
+  case "${MODE}" in
+  "sync")
+    echo "$(date -Iseconds) Patching configmap ${CONFIGMAP_NAME} to enable sync and disable prune"
+    # disable prune, enable sync-to-gcs
+    PATCH_DATA='{"data":{"BSC_PRUNE":"False","SYNC_TO_GCS":"True"}}'
+    ;;
+  "prune")
+    echo "$(date -Iseconds) Patching configmap ${CONFIGMAP_NAME} to enable prune and disable sync"
+    # disable sync-to-gcs, enable prune
+    PATCH_DATA='{"data":{"BSC_PRUNE":"True","SYNC_TO_GCS":"False"}}'
+    ;;
+  "*")
+     check_ret 1 "$(date -Iseconds) Mode value \"${MODE}\" is incorrect, abort"
+     ;;
+  esac
+  ${KUBECTL} patch configmap "${CONFIGMAP_NAME}"  --type merge --patch ${PATCH_DATA}
+  ret=$?
+  check_ret "${ret}" "$(date -Iseconds) Fatal: cannot patch configmap ${CONFIGMAP_NAME}, abort"
+
+  echo "$(date -Iseconds) Deleting pod ${POD_NAME} to trigger action inside init container ..."
+  # delete the pod to trigger action inside init container
+  ${KUBECTL} delete pod "${POD_NAME}" --wait=false
+  ret=$?
+  check_ret "${ret}" "$(date -Iseconds) Fatal: cannot delete pod ${POD_NAME}, abort"
+  echo "$(date -Iseconds) Pod ${POD_NAME} deleted successfully, exiting. Check pod logs after respawn."
+else
+  # pod is terminating now, try later on next iteration
+  echo "$(date -Iseconds) Pod ${POD_NAME} is terminating now, nothing to do, exiting"
+  exit 0
+fi

--- a/dysnix/bsc/templates/scripts/_gcs_cleanup.tpl
+++ b/dysnix/bsc/templates/scripts/_gcs_cleanup.tpl
@@ -1,0 +1,45 @@
+#!/usr/bin/env sh
+set -ex
+
+# env required
+# AWS_ACCESS_KEY_ID
+# AWS_SECRET_ACCESS_KEY
+
+DATA_DIR="{{ .Values.bsc.base_path }}"
+RMLIST="${DATA_DIR}/{{ .Values.gcsCleanup.rmlist }}"
+GSUTIL="/google-cloud-sdk/bin/gsutil"
+GCLOUD="/google-cloud-sdk/bin/gcloud"
+BOTOCONFIG="${HOME}/.boto"
+
+# allow container interrupt
+trap "{ exit 1; }" INT TERM
+
+# disable gcloud auth
+${GCLOUD} config set pass_credentials_to_gsutil false
+# using env vars to auth to GCS, as we use these env vars for s5cmd already
+set -x
+echo -e "[Credentials]\ngs_access_key_id = ${AWS_ACCESS_KEY_ID}\ngs_secret_access_key = ${AWS_SECRET_ACCESS_KEY}" > "${BOTOCONFIG}"
+set +x
+
+# creating empty list if missing, f.e .no sync-to-gcs were running
+touch "${RMLIST}"
+
+OBJ_TO_REMOVE=$(wc -l < "${RMLIST}")
+set +e
+if [ "${OBJ_TO_REMOVE}" -gt "10000" ];then
+  split -l 2000 "${RMLIST}" /tmp/rmlist-
+  find /tmp -name "rmlist-*" -print0| xargs -0 -P 50 -n1 -I{} bash -c "nice ${GSUTIL} rm -f -I < {}"
+else
+  if [ "${OBJ_TO_REMOVE}" -gt "0" ];then
+    time ${GSUTIL} -m rm -I < "${RMLIST}"
+  else
+    echo "No objects to remove"
+  fi
+fi
+
+# cleanup removal list
+true > "${RMLIST}"
+
+# sleep in an endless cycle to allow container interrupt
+set +x
+while true; do sleep 10;done

--- a/dysnix/bsc/templates/scripts/_init_from_gcs.tpl
+++ b/dysnix/bsc/templates/scripts/_init_from_gcs.tpl
@@ -1,0 +1,159 @@
+#!/usr/bin/env sh
+set -ex # -e exits on error
+
+# env required
+# S3_ENDPOINT_URL # f.e. "https://storage.googleapis.com"
+# AWS_ACCESS_KEY_ID
+# AWS_SECRET_ACCESS_KEY
+
+DATA_DIR="{{ .Values.bsc.base_path }}"
+CHAINDATA_DIR="${DATA_DIR}/geth/chaindata"
+INITIALIZED_FILE="${DATA_DIR}/.initialized"
+#without gs:// or s3://, just a bucket name and path
+INDEX_URL="{{ .Values.bsc.initFromGCS.indexUrl }}"
+S5CMD=/s5cmd
+EXCLUDE_ANCIENT='--exclude "*.cidx" --exclude "*.ridx" --exclude "*.cdat" --exclude "*.rdat"'
+EXCLUDE_STATE='--exclude "*.ldb"'
+INDEX="index"
+S_UPDATING="/updating"
+S_TIMESTAMP="/timestamp"
+S_STATE_URL="/state_url"
+S_ANCIENT_URL="/ancient_url"
+S_STATS="/stats"
+
+{{- if .Values.bsc.forceInitFromSnapshot }}
+rm -f "${INITIALIZED_FILE}"
+{{- end }}
+
+if [ -f "${INITIALIZED_FILE}" ]; then
+    echo "Blockchain already initialized. Exiting..."
+    exit 0
+fi
+
+# Cleanup
+rm -rf ${DATA_DIR}/geth
+
+# we need to create temp files
+cd /tmp
+
+# get index of source base dirs
+${S5CMD} cp "s3://${INDEX_URL}" "${INDEX}"
+
+# get the most fresh datadir
+# prune time is ignored here, we assume that all datadirs are pruned frequently enough
+GCS_BASE_URL=""
+MAX_TIMESTAMP=1
+for _GCS_BASE_URL in $(cat ${INDEX});do
+  _TIMESTAMP_URL="${_GCS_BASE_URL}${S_TIMESTAMP}"
+  _TIMESTAMP=$(${S5CMD} cat s3://${_TIMESTAMP_URL})
+  if [ "${_TIMESTAMP}" -gt "${MAX_TIMESTAMP}" ];then
+    GCS_BASE_URL="${_GCS_BASE_URL}"
+    MAX_TIMESTAMP=${_TIMESTAMP}
+  fi
+done
+
+if [ "${GCS_BASE_URL}" == "" ];then
+  echo "Fatal: cannot pick up correct base url, exiting"
+  exit 1
+fi
+
+
+UPDATING_URL="${GCS_BASE_URL}${S_UPDATING}"
+TIMESTAMP_URL="${GCS_BASE_URL}${S_TIMESTAMP}"
+STATS_URL="${GCS_BASE_URL}${S_STATS}"
+
+# get state and ancient sources
+STATE_URL="${GCS_BASE_URL}${S_STATE_URL}"
+ANCIENT_URL="${GCS_BASE_URL}${S_ANCIENT_URL}"
+
+
+STATE_SRC="$(${S5CMD} cat s3://${STATE_URL})"
+ANCIENT_SRC="$(${S5CMD} cat s3://${ANCIENT_URL})"
+REMOTE_STATS="$(${S5CMD} cat s3://${STATS_URL})"
+
+# create dst dirs
+mkdir -p "${CHAINDATA_DIR}/ancient"
+
+# save sync source
+echo "${GCS_BASE_URL}" > "${DATA_DIR}/source"
+
+set +e
+
+# some background monitoring for humans
+set +x
+while true;do
+  INODES=$(df -Phi ${DATA_DIR} | tail -n 1 | awk '{print $3}')
+  SIZE=$(df -P -BG ${DATA_DIR} | tail -n 1 | awk '{print $3}')G
+  echo -e "$(date -Iseconds) | DST USED Inodes:\t${INODES} Size:\t${SIZE} | SOURCE TOTAL ${REMOTE_STATS}"
+  sleep 2
+done &
+MON_PID=$!
+set -x
+
+# get start and stop timestamps from the cloud
+UPDATING_0="$(${S5CMD} cat s3://${UPDATING_URL})"
+TIMESTAMP_0="$(${S5CMD} cat s3://${TIMESTAMP_URL})"
+
+
+# we're ready to perform actual data sync
+
+# we're done when both are true
+# 1) start and stop timestamps did not changed during data sync - no process started or finished updating the cloud
+# 2) 0 objects copied
+SYNC=2
+while [ "${SYNC}" -gt 0 ] ; do
+
+    # sync from cloud to local disk, without removing existing [missing in the cloud] files
+    # run multiple syncs in background
+
+    # we don't wanna sync ancient data here
+    time ${S5CMD} cp -n -s -u ${EXCLUDE_ANCIENT} s3://${STATE_SRC}/* ${CHAINDATA_DIR}/ > cplist_state.txt &
+    STATE_CP_PID=$!
+    time nice ${S5CMD} cp -n -s -u --part-size 200 --concurrency 2 ${EXCLUDE_STATE} s3://${ANCIENT_SRC}/* ${CHAINDATA_DIR}/ancient/ > cplist_ancient.txt &
+    ANCIENT_CP_PID=$!
+
+    # wait for all syncs to complete
+    # TODO any errors handling here?
+    wait ${STATE_CP_PID} ${ANCIENT_CP_PID}
+
+    # stop monitoring
+    if [ ${MON_PID} -ne 0 ];then
+      kill ${MON_PID}
+      MON_PID=0
+    fi
+
+    # get start and stop timestamps from the cloud after sync
+    UPDATING_1="$(${S5CMD} cat s3://${UPDATING_URL})"
+    TIMESTAMP_1="$(${S5CMD} cat s3://${TIMESTAMP_URL})"
+
+    # compare timestamps before and after sync
+    if [ "${UPDATING_0}" -eq "${UPDATING_1}" ] && [ "${TIMESTAMP_0}" -eq "${TIMESTAMP_1}" ];then
+      echo "Timestamps are equal"
+      echo -e "U_0=${UPDATING_0}\tU_1=${UPDATING_1},\tT_0=${TIMESTAMP_0}\tT_1=${TIMESTAMP_1}"
+      let SYNC=SYNC-1
+    else
+      echo "Timestamps changed, running sync again ..."
+      echo -e "U_0=${UPDATING_0}\tU_1=${UPDATING_1},\tT_0=${TIMESTAMP_0}\tT_1=${TIMESTAMP_1}"
+      # end  timestamps -> begin timestamps
+      UPDATING_0=${UPDATING_1}
+      TIMESTAMP_0=${TIMESTAMP_1}
+      SYNC=2
+      continue
+    fi
+
+    # get number of objects copied
+    CP_OBJ_NUMBER_STATE=$(wc -l <  cplist_state.txt )
+    CP_OBJ_NUMBER_ANCIENT=$(wc -l < cplist_ancient.txt )
+    #  0 objects copied ?
+    if [ "${CP_OBJ_NUMBER_STATE}" -eq 0 ] && [ "${CP_OBJ_NUMBER_ANCIENT}" -eq 0 ];then
+      echo -e "State objects copied:\t${CP_OBJ_NUMBER_STATE}, ancient objects copied:\t${CP_OBJ_NUMBER_ANCIENT}"
+      let SYNC=SYNC-1
+    else
+      echo -e "State objects copied:\t${CP_OBJ_NUMBER_STATE}, ancient objects copied:\t${CP_OBJ_NUMBER_ANCIENT}, running sync again ... "
+      SYNC=2
+      continue
+    fi
+done
+
+# Mark data dir as initialized
+touch ${INITIALIZED_FILE}

--- a/dysnix/bsc/templates/scripts/_init_from_rsync.tpl
+++ b/dysnix/bsc/templates/scripts/_init_from_rsync.tpl
@@ -25,11 +25,11 @@ fi
 
 set +e
 # remove missing files to cleanup
-rsync -av --delete-before ${SNAPSHOT_URL}/ ${DATA_DIR}/
+rsync -av --inplace --delete-before ${SNAPSHOT_URL}/ ${DATA_DIR}/
 # add more times to catch up
-rsync -av ${SNAPSHOT_URL}/ ${DATA_DIR}/
-rsync -av ${SNAPSHOT_URL}/ ${DATA_DIR}/
-rsync -av ${SNAPSHOT_URL}/ ${DATA_DIR}/
+rsync -av --inplace ${SNAPSHOT_URL}/ ${DATA_DIR}/
+rsync -av --inplace ${SNAPSHOT_URL}/ ${DATA_DIR}/
+rsync -av --inplace ${SNAPSHOT_URL}/ ${DATA_DIR}/
 set -e
 
 # Mark data dir as initialized

--- a/dysnix/bsc/templates/scripts/_init_from_snaphot.tpl
+++ b/dysnix/bsc/templates/scripts/_init_from_snaphot.tpl
@@ -20,7 +20,7 @@ rm -rf ${DATA_DIR}/geth
 # Download & extract snapshot
 # special handling of zstd
 if [[ "${SNAPSHOT_URL}" =~ "\.zst$" ]]; then
-  wget ${SNAPSHOT_URL} -O - | mbuffer -m5% -q -l /tmp/m1.log | zstd -d -T0 | mbuffer -m5% -q -l /tmp/m2.log | tar --overwrite -x -C ${DATA_DIR}
+  wget ${SNAPSHOT_URL} -O - | mbuffer -m5% -q -l /tmp/m1.log | zstd -d -T0 | mbuffer -m5% -q -l /tmp/m2.log | tar -b 2048 --overwrite -x -C ${DATA_DIR}
 else
   wget ${SNAPSHOT_URL} -O - | tar --overwrite -x -C ${DATA_DIR}
 fi

--- a/dysnix/bsc/templates/scripts/_prune.tpl
+++ b/dysnix/bsc/templates/scripts/_prune.tpl
@@ -1,0 +1,28 @@
+#!/usr/bin/env sh
+
+set -x
+# env required
+# BSC_PRUNE = True or any other value
+
+DATA_DIR="{{ .Values.bsc.base_path }}"
+
+# TODO
+# mark cloud timestamp as outdated, as we're not going to provide a fresh snapshot soon
+# it should be done by operator - just keep pod up & running for some time and cloud timestamp will lag on it's own
+
+GETH=/usr/local/bin/geth
+
+ret=0
+# we need to check env var to start pruning
+if [ "${BSC_PRUNE}" == "True" ] ; then
+  # background logging
+  tail -F "${DATA_DIR}/bsc.log" &
+  $GETH --config=/config/config.toml --datadir=${DATA_DIR} --cache {{ .Values.bsc.cache }} snapshot prune-state
+  ret=$?
+  if [ "${ret}" -eq "0" ];then
+    # update timestamp
+    date +%s > "${DATA_DIR}/prune_timestamp"
+  fi
+fi
+
+exit $ret

--- a/dysnix/bsc/templates/scripts/_sync_to_gcs.tpl
+++ b/dysnix/bsc/templates/scripts/_sync_to_gcs.tpl
@@ -1,0 +1,97 @@
+#!/usr/bin/env sh
+set -ex # -e exits on error
+
+# env required
+# S3_ENDPOINT_URL # f.e. "https://storage.googleapis.com"
+# AWS_ACCESS_KEY_ID
+# AWS_SECRET_ACCESS_KEY
+# SYNC_TO_GCS True or any other value
+
+# enable sync via env
+if [ "${SYNC_TO_GCS}" != "True" ];then
+  exit 0
+fi
+
+DATA_DIR="{{ .Values.bsc.base_path }}"
+CHAINDATA_DIR="${DATA_DIR}/geth/chaindata"
+#without gs:// or s3://, just a bucket name and path
+GCS_BASE_URL="{{ .Values.bsc.syncToGCS.baseUrl }}"
+# GSUTIL=$(which gsutil)
+
+S5CMD=/s5cmd
+CPLOG="${DATA_DIR}/cplog.txt"
+CPLIST="${DATA_DIR}/cplist.txt"
+RMLOG="${DATA_DIR}/rmlog.txt"
+RMLIST="${DATA_DIR}/rmlist.txt"
+
+# s5cmd excludes just by file extension, not by file path
+EXCLUDE_ANCIENT='--exclude "*.cidx" --exclude "*.ridx" --exclude "*.cdat" --exclude "*.rdat"'
+EXCLUDE_STATE='--exclude "*.ldb"'
+
+S_UPDATING="/updating"
+S_TIMESTAMP="/timestamp"
+S_STATE_URL="/state_url"
+S_ANCIENT_URL="/ancient_url"
+S_STATS="/stats"
+
+if [ "${GCS_BASE_URL}" == "" ];then
+  echo "Fatal: cannot use empty base url, exiting"
+  exit 1
+fi
+
+# we need to create temp files
+cd /tmp
+
+# get timestamp, state and ancient DSTs
+UPDATING_URL="${GCS_BASE_URL}${S_UPDATING}"
+TIMESTAMP_URL="${GCS_BASE_URL}${S_TIMESTAMP}"
+STATS_URL="${GCS_BASE_URL}${S_STATS}"
+
+STATE_URL="${GCS_BASE_URL}${S_STATE_URL}"
+ANCIENT_URL="${GCS_BASE_URL}${S_ANCIENT_URL}"
+
+STATE_DST="$(${S5CMD} cat s3://${STATE_URL})"
+ANCIENT_DST="$(${S5CMD} cat s3://${ANCIENT_URL})"
+
+# mark begin of sync in the cloud
+date +%s > updating
+${S5CMD} cp updating "s3://${UPDATING_URL}"
+
+# we're ready to perform actual data copy
+
+# sync from local disk to cloud, without removing existing [missing on local disk] files
+# run multiple syncs in background
+# cp is recursive by default, thus we need to exclude ancient data here
+time ${S5CMD} cp -n -s -u ${EXCLUDE_ANCIENT} "${CHAINDATA_DIR}/" "s3://${STATE_DST}/"  > cplist_state.txt &
+time nice ${S5CMD} cp -n -s -u --part-size 200 --concurrency 2 ${EXCLUDE_STATE} "${CHAINDATA_DIR}/ancient/" "s3://${ANCIENT_DST}/"  > cplist_ancient.txt &
+# wait for all syncs to complete
+# TODO any errors handling here?
+wait
+
+# update timestamp
+# TODO store timestamp inside readinnes check and use it instead of now()
+date +%s > timestamp
+${S5CMD} cp timestamp "s3://${TIMESTAMP_URL}"
+
+# update stats
+INODES=$(df -Phi "${DATA_DIR}" | tail -n 1 | awk '{print $3}')
+# force GB output
+SIZE=$(df -P -BG "${DATA_DIR}" | tail -n 1 | awk '{print $3}')G
+echo -ne "Inodes:\t${INODES} Size:\t${SIZE}" > stats
+${S5CMD} cp stats "s3://${STATS_URL}"
+
+# get number of objects copied
+cat cplist_state.txt cplist_ancient.txt > "${CPLIST}"
+# we use a heuristic here - lot of uploaded objects => lot of object to remove in the cloud => we need to generate removal list
+CP_OBJ_NUMBER=$(wc -l < "${CPLIST}")
+echo "$(date -Iseconds) Uploaded objects: ${CP_OBJ_NUMBER}" | tee -a "${CPLOG}"
+set +e
+if [ "${CP_OBJ_NUMBER}" -gt 1000 ] ;then
+  set -e
+  # s5cmd doesn't support GCS object removal, just generate a list of files to remove via gsutil
+  # removal should be done in another sidecar
+  time $S5CMD --dry-run cp -n ${EXCLUDE_ANCIENT} "s3://${STATE_DST}/*" "${CHAINDATA_DIR}/" | awk '{print $2}'|sed 's/^s3/gs/' > rmlist.txt
+  time $S5CMD --dry-run cp -n ${EXCLUDE_STATE} "s3://${ANCIENT_DST}/*" "${CHAINDATA_DIR}/ancient/" | awk '{print $2}'|sed 's/^s3/gs/' >> rmlist.txt
+  echo "$(date -Iseconds) Objects to remove: $(wc -l < rmlist.txt)" | tee -a "${RMLOG}"
+  cp rmlist.txt "${RMLIST}"
+fi

--- a/dysnix/bsc/templates/secret.yaml
+++ b/dysnix/bsc/templates/secret.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.bsc.initFromGCS.enabled -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "{{ .Release.Name }}-gcs-creds-init-from"
+  labels: {{ include "bsc.labels" . | nindent 4 }}
+type: Opaque
+data:
+  S3_ENDPOINT_URL: {{ .Values.bsc.initFromGCS.endpoint | b64enc | quote }}
+  AWS_ACCESS_KEY_ID: {{ .Values.bsc.initFromGCS.keyID | b64enc | quote }}
+  AWS_SECRET_ACCESS_KEY: {{ .Values.bsc.initFromGCS.accessKey | b64enc | quote }}
+{{- end }}
+{{- if .Values.bsc.syncToGCS.enabled }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "{{ .Release.Name }}-gcs-creds-sync-to"
+  labels: {{ include "bsc.labels" . | nindent 4 }}
+type: Opaque
+data:
+  S3_ENDPOINT_URL: {{ .Values.bsc.syncToGCS.endpoint | b64enc | quote }}
+  AWS_ACCESS_KEY_ID: {{ .Values.bsc.syncToGCS.keyID | b64enc | quote }}
+  AWS_SECRET_ACCESS_KEY: {{ .Values.bsc.syncToGCS.accessKey | b64enc | quote }}
+{{- end }}

--- a/dysnix/bsc/templates/service.yaml
+++ b/dysnix/bsc/templates/service.yaml
@@ -2,8 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Release.Name }}
-  labels:
-{{ include "bsc.labels" . | indent 4 }}
+  labels: {{ include "bsc.labels" . | nindent 4 }}
 spec:
   type:  {{ .Values.service.type }}
   ports:

--- a/dysnix/bsc/templates/serviceaccount.yaml
+++ b/dysnix/bsc/templates/serviceaccount.yaml
@@ -3,8 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "bsc.serviceAccountName" . }}
-  labels:
-    {{- include "bsc.labels" . | nindent 4 }}
+  labels: {{ include "bsc.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/dysnix/bsc/templates/servicemonitor.yaml
+++ b/dysnix/bsc/templates/servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "bsc.fullname" . }}
+  labels: {{ include "bsc.labels" . | nindent 4 }}
 spec:
   endpoints:
   - interval: 1m

--- a/dysnix/bsc/templates/statefulset.yaml
+++ b/dysnix/bsc/templates/statefulset.yaml
@@ -228,6 +228,25 @@ spec:
           - name: rsyncd-config
             mountPath: /config
       {{- end }}
+      {{- if .Values.gcsCleanup.enabled }}
+      - name: gcs-cleanup
+        image: {{ .Values.gcsCleanup.image }}
+        imagePullPolicy: IfNotPresent
+        command:
+          - /bin/sh
+          - /scripts/gcs_cleanup.sh
+        env:
+          - name: HOME
+            value: "/tmp"
+        envFrom:
+          - secretRef:
+              name: "{{ .Release.Name }}-gcs-creds-sync-to"
+        volumeMounts:
+          - name: bsc-pvc
+            mountPath: {{ .Values.rsyncd.bsc_path }}
+          - name: scripts
+            mountPath: /scripts
+      {{- end }}
       initContainers:
       {{- if .Values.bsc.initGenesis }}
       - name: init-genesis
@@ -248,6 +267,22 @@ spec:
         command:
           - /bin/sh
           - /scripts/init_from_snaphot.sh
+        volumeMounts:
+          - name: bsc-pvc
+            mountPath: {{ .Values.bsc.base_path }}
+          - name: scripts
+            mountPath: /scripts
+      {{- end }}
+      {{- if .Values.bsc.initFromGCS.enabled }}
+      - name: init-from-gcs
+        image: {{ .Values.bsc.initFromGCS.image }}
+        imagePullPolicy: IfNotPresent
+        command:
+          - /bin/sh
+          - /scripts/init_from_gcs.sh
+        envFrom:
+          - secretRef:
+              name: "{{ .Release.Name }}-gcs-creds-init-from"
         volumeMounts:
           - name: bsc-pvc
             mountPath: {{ .Values.bsc.base_path }}
@@ -303,7 +338,6 @@ spec:
             mountPath: /generated-config
           - name: scripts
             mountPath: /scripts
-
         {{- if .Values.bsc.getNodeKey }}
       - name: get-nodekey
         {{- if eq .Values.controller "StatefulSet" }}
@@ -343,6 +377,42 @@ spec:
           - name: bsc-pvc
             mountPath: {{ .Values.bsc.base_path }}
       {{- end }}
+      {{- if .Values.bsc.syncToGCS.enabled }}
+      - name: sync-to-gcs
+        image: {{ .Values.bsc.syncToGCS.image }}
+        imagePullPolicy: IfNotPresent
+        command:
+          - /bin/sh
+          - /scripts/sync_to_gcs.sh
+        envFrom:
+          - secretRef:
+              name: "{{ .Release.Name }}-gcs-creds-sync-to"
+          - configMapRef:
+              name: "{{ .Release.Name }}-env"
+        volumeMounts:
+          - name: bsc-pvc
+            mountPath: {{ .Values.bsc.base_path }}
+          - name: scripts
+            mountPath: /scripts
+      {{- end }}
+      {{- if .Values.bsc.prune.enabled }}
+      - name: bsc-prune
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: IfNotPresent
+        command:
+          - /bin/sh
+          - /scripts/prune.sh
+        envFrom:
+        - configMapRef:
+            name: "{{ .Release.Name }}-env"
+        volumeMounts:
+          - name: bsc-pvc
+            mountPath: {{ .Values.bsc.base_path }}
+          - name: scripts
+            mountPath: /scripts
+          - name: generated-bsc-config
+            mountPath: /config
+      {{- end }}
       volumes:
         - name: bsc-config
           configMap:
@@ -369,7 +439,6 @@ spec:
           configMap:
             name: "{{ .Release.Name }}-nginx-config"
         {{- end }}
-  {{- if .Values.persistence.enabled }}
   volumeClaimTemplates:
     - metadata:
         name: bsc-pvc
@@ -389,4 +458,3 @@ spec:
           requests:
             storage: {{ .Values.persistence.size }}
         volumeMode: Filesystem
-  {{- end }}

--- a/dysnix/bsc/templates/statefulset.yaml
+++ b/dysnix/bsc/templates/statefulset.yaml
@@ -8,8 +8,7 @@ kind: CloneSet
 {{- end }}
 metadata:
   name: {{ include "bsc.fullname" . }}
-  labels:
-{{ include "bsc.labels" . | indent 4 }}
+  labels: {{ include "bsc.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }} # by default is 1
   updateStrategy:

--- a/dysnix/bsc/templates/statefulset.yaml
+++ b/dysnix/bsc/templates/statefulset.yaml
@@ -76,7 +76,7 @@ spec:
           - --gcmode={{ .Values.bsc.gcmode }}
           - --maxpeers={{ .Values.bsc.maxpeers }}
           - --cache={{ .Values.bsc.cache }}
-          - --snapshot=false
+          - --snapshot={{ .Values.bsc.snapshot }}
           - --port={{ .Values.service.p2pPort0 }}
           - --rpc.allow-unprotected-txs
           - --txlookuplimit=0

--- a/dysnix/bsc/values.yaml
+++ b/dysnix/bsc/values.yaml
@@ -84,6 +84,22 @@ bsc:
   initFromSnapshotImage: dysnix/zstd:v3.15.1
   initFromRsync: false
   initFromRsyncImage: instrumentisto/rsync-ssh:latest
+  initFromGCS:
+    enabled: false
+    image: peakcom/s5cmd:v1.4.0
+    endpoint: "https://storage.googleapis.com"
+    keyID: "AWS_ACCESS_KEY_ID"
+    accessKey: "AWS_SECRET_ACCESS_KEY"
+    indexUrl: "bucket/path/to/file"
+  syncToGCS:
+    enabled: false
+    image: peakcom/s5cmd:v1.4.0
+    endpoint: "https://storage.googleapis.com"
+    keyID: "AWS_ACCESS_KEY_ID"
+    accessKey: "AWS_SECRET_ACCESS_KEY"
+    baseUrl: "bucket/path/to/dir"
+  prune:
+    enabled: false
   forceInitFromSnapshot: false
   snapshotUrl:
   snapshotRsyncUrl: "rsync://192.168.8.4/snapshot/geth/node/geth"
@@ -211,7 +227,24 @@ rsyncd:
   service:
     port: 1873
     name: rsyncd
-
+# clean up GCS using a list from sync-to-gcs
+# workload identity is used
+gcsCleanup:
+  enabled: false
+  image: google/cloud-sdk:alpine
+  rmlist: rmlist.txt
+# cronjobs to initiate sync-to-gcs and prune via pod restart
+cronjobs:
+  sync:
+    enabled: false
+    image: dysnix/kubectl:v1.20
+    resources: {}
+    schedule: "*/20 * * * *"
+  prune:
+    enabled: false
+    image: dysnix/kubectl:v1.20
+    resources: {}
+    schedule: "5 3 * * 2"
 nginx:
   overrideBackendAddress: false
   backendAddress:

--- a/dysnix/bsc/values.yaml
+++ b/dysnix/bsc/values.yaml
@@ -77,6 +77,7 @@ bsc:
   graphQlVhosts: "*"
   maxpeers: 50
   cache: 8192
+  snapshot: false
   noDiscovery: false
   initGenesis: false
   initFromSnapshot: false


### PR DESCRIPTION
* add init `init-from-gcs` using [s5cmd](https://github.com/peak/s5cmd)
* add init `sync-to-gcs` using s5cmd
* add sidecar `gcs-cleanup` to remove unneded files in the cloud after `sync-to-gcs`
* add init `prune` to perform [node pruning](https://docs.binance.org/smart-chain/developer/fullnode.html#storage)
* add cronjobs to trigger `sync-to-gcs` and `prune`
* add/fix labels
* various small fixes
* no breaking changes, bump minor version due to a lot of changes only