### PR TITLE
[bsc] scaling improvements

### DIFF
--- a/dysnix/bsc/Chart.yaml
+++ b/dysnix/bsc/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: bsc
 description: Binance Smart Chain chart for Kubernetes
-version: "0.6.1"
+version: "0.6.2"
 appVersion: "v1.1.7"
 
 keywords:

--- a/dysnix/bsc/templates/_helpers.tpl
+++ b/dysnix/bsc/templates/_helpers.tpl
@@ -54,3 +54,11 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{- define "bsc.scaleTriggerName" -}}
+{{- printf "%s-%s" (include "bsc.fullname" .) "s-t" -}}
+{{- end }}
+
+{{- define "bsc.scaleHelperrName" -}}
+{{- printf "%s-%s" (include "bsc.fullname" .) "s-h" -}}
+{{- end }}

--- a/dysnix/bsc/templates/configmap.yaml
+++ b/dysnix/bsc/templates/configmap.yaml
@@ -65,6 +65,10 @@ data:
     {{- include (print $.Template.BasePath "/scripts/_prune.tpl") . | nindent 4 }}
   cron.sh: |-
     {{- include (print $.Template.BasePath "/scripts/_cron.tpl") . | nindent 4 }}
+  update-pod-deletion-cost.sh: |-
+    {{- include (print $.Template.BasePath "/scripts/_update_pod_deletion_cost.tpl") . | nindent 4 }}
+  controller-hook.sh: |-
+    {{- include (print $.Template.BasePath "/scripts/_controller_hook.tpl") . | nindent 4 }}
 ---
 {{- if .Values.failback.enabled }}
 apiVersion: v1

--- a/dysnix/bsc/templates/configs/_nginx.txt
+++ b/dysnix/bsc/templates/configs/_nginx.txt
@@ -24,6 +24,12 @@ http {
     proxy_send_timeout 1s;
     client_max_body_size 100m;
 
+    gzip on;
+    gzip_comp_level 2;
+    gzip_min_length 100;
+    gzip_proxied expired no-cache no-store private auth;
+    gzip_types text/plain application/json;
+
     map $connection $fallback {
       default bsc-dataseed.binance.org;
       "~[0-3]$" bsc-dataseed1.ninicoin.io;

--- a/dysnix/bsc/templates/force-scale-helper.yaml
+++ b/dysnix/bsc/templates/force-scale-helper.yaml
@@ -1,0 +1,60 @@
+{{- if .Values.autoScaleHelper.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "bsc.scaleHelperrName" . }}
+  labels: {{ include "bsc.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "bsc.scaleHelperrName" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "bsc.scaleHelperrName" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        bsc/role: "auto-scale-helper"
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "bsc.serviceAccountName" . }}
+      containers:
+        - name: helper
+          image: {{ .Values.autoScaleHelper.image }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+          volumeMounts:
+            - name: scripts
+              mountPath: /hooks/controller-hook.sh
+              subPath: controller-hook.sh
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32M
+            limits:
+              cpu: 100m
+              memory: 128M
+      volumes:
+        - name: scripts
+          configMap:
+            name: "{{ .Release.Name }}-scripts"
+            defaultMode: 0755
+      {{- with .Values.autoScaleHelper.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.autoScaleHelper.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.autoScaleHelper.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/dysnix/bsc/templates/force-scale-trigger.yaml
+++ b/dysnix/bsc/templates/force-scale-trigger.yaml
@@ -1,0 +1,67 @@
+{{- if .Values.autoScaleTrigger.enabled }}
+{{- if eq .Values.controller "StatefulSet" }}
+apiVersion: apps/v1
+kind: StatefulSet
+{{- end }}
+{{- if eq .Values.controller "CloneSet" }}
+apiVersion: apps.kruise.io/v1alpha1
+kind: CloneSet
+{{- end }}
+metadata:
+  name: {{ include "bsc.scaleTriggerName" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "bsc.scaleTriggerName" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  replicas: {{ .Values.replicaCount }} # by default is 1
+  updateStrategy:
+  {{- toYaml .Values.updateStrategy | nindent 4 }}
+  {{- if eq .Values.controller "StatefulSet" }}
+  serviceName: {{ include "bsc.scaleTriggerName" . }}
+  podManagementPolicy: {{ .Values.podManagementPolicy }}
+  {{- end }}
+  {{- if eq .Values.controller "CloneSet" }}
+  minReadySeconds: {{ .Values.minReadySeconds }}
+  scaleStrategy:
+  {{- toYaml .Values.scaleStrategy | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "bsc.scaleTriggerName" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "bsc.scaleTriggerName" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        bsc/role: "auto-scale-trigger"
+      annotations:
+        {{- if eq .Values.controller "CloneSet" }}
+        controller.kubernetes.io/pod-deletion-cost: {{ .Values.podDeletionCost | quote }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "bsc.serviceAccountName" . }}
+      {{- with .Values.securityContext }}
+      securityContext:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.autoScaleTrigger.affinity }}
+      affinity:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      terminationGracePeriodSeconds: 60
+      containers:
+        {{- toYaml .Values.autoScaleTrigger.containers | nindent 8 }}
+{{- end }}

--- a/dysnix/bsc/templates/scripts/_controller_hook.tpl
+++ b/dysnix/bsc/templates/scripts/_controller_hook.tpl
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+# This is needed to work-around GKE local SSD scale up issue https://github.com/kubernetes/autoscaler/issues/2145
+
+# watch for scale-related changes in the specified controller
+# in scale up case -> scale up secondary controller to the same replica value
+# in scale down case -> scale down secondary controller to 0
+
+controller={{ .Values.controller }}
+{{- if eq  .Values.controller "StatefulSet" }}
+apiVersion="apps/v1"
+{{- end }}
+{{- if eq .Values.controller "CloneSet" }}
+apiVersion="apps.kruise.io/v1alpha1"
+{{- end }}
+
+watchName="OnModified${controller}"
+debugLog="/tmp/debug.log"
+
+if [[ $1 == "--config" ]] ; then
+  cat <<EOF
+configVersion: v1
+kubernetes:
+- name: "${watchName}"
+  apiVersion: ${apiVersion}
+  kind: $controller
+  executeHookOnEvent: ["Modified"]
+  labelSelector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "bsc.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  namespace:
+    nameSelector:
+      matchNames: ["{{ .Release.Namespace }}"]
+  jqFilter: ".spec.replicas"
+EOF
+else
+	# ignore Synchronization for simplicity
+	type=$(jq -r '.[0].type' "${BINDING_CONTEXT_PATH}")
+	if [[ "${type}" == "Synchronization" ]] ; then
+	  echo Got Synchronization event
+	  exit 0
+	fi
+  	ARRAY_COUNT=$(jq -r '. | length-1' "${BINDING_CONTEXT_PATH}")
+	for i in $(seq 0 "${ARRAY_COUNT}");do
+		bindingName=$(jq -r ".[$i].binding" "${BINDING_CONTEXT_PATH}")
+		resourceEvent=$(jq -r ".[$i].watchEvent" "${BINDING_CONTEXT_PATH}")
+		resourceName=$(jq -r ".[$i].object.metadata.name" "${BINDING_CONTEXT_PATH}")
+		if [[ "${bindingName}" == "${watchName}" && "${resourceEvent}" == "Modified" ]] ; then
+		  	echo "${controller} ${resourceName} was scaled"
+		  	newReplicas=$(jq -r ".[$i].object.spec.replicas" "${BINDING_CONTEXT_PATH}")
+        oldReplicas=$(jq -r ".[$i].object.status.replicas" "${BINDING_CONTEXT_PATH}")
+        addController=$(jq -r ".[$i].object.metadata.annotations.additionalControllerName" "${BINDING_CONTEXT_PATH}")
+        namespace=$(jq -r ".[$i].object.metadata.namespace" "${BINDING_CONTEXT_PATH}")
+        if [[ "${newReplicas}" -gt "${oldReplicas}" ]];then
+          echo "$(date -Iseconds) scale UP ${controller} ${addController}, new=${newReplicas}, old=${oldReplicas}" | tee -a "${debugLog}"
+          kubectl --namespace "${namespace}" scale "${controller}" "${addController}" --replicas="${newReplicas}"
+        fi
+        if [[ "${newReplicas}" -lt "${oldReplicas}" ]];then
+          echo "$(date -Iseconds) scale DOWN ${controller} ${addController} to 0, new=${newReplicas}, old=${oldReplicas}" | tee -a "${debugLog}"
+          kubectl --namespace "${namespace}" scale "${controller}" "${addController}" --replicas=0
+        fi
+		fi
+	done
+#	echo  "$(date -Iseconds)"  >> "${debugLog}"
+#	cat "${BINDING_CONTEXT_PATH}" | jq . >> "${debugLog}"
+fi

--- a/dysnix/bsc/templates/scripts/_init_from_gcs.tpl
+++ b/dysnix/bsc/templates/scripts/_init_from_gcs.tpl
@@ -84,7 +84,7 @@ set +x
 while true;do
   INODES=$(df -Phi ${DATA_DIR} | tail -n 1 | awk '{print $3}')
   SIZE=$(df -P -BG ${DATA_DIR} | tail -n 1 | awk '{print $3}')G
-  echo -e "$(date -Iseconds) | DST USED Inodes:\t${INODES} Size:\t${SIZE} | SOURCE TOTAL ${REMOTE_STATS}"
+  echo -e "$(date -Iseconds) | SOURCE TOTAL ${REMOTE_STATS} | DST USED Inodes:\t${INODES} Size:\t${SIZE}"
   sleep 2
 done &
 MON_PID=$!

--- a/dysnix/bsc/templates/scripts/_update_pod_deletion_cost.tpl
+++ b/dysnix/bsc/templates/scripts/_update_pod_deletion_cost.tpl
@@ -1,0 +1,47 @@
+#!/usr/bin/env sh
+
+# this script updates "pod-deletion-cost" pod annotation based on disk usage
+
+# required env
+# MY_POD_NAME - pod name to annotate
+
+# get used space from this dir's mount point
+DATA_DIR="${1}"
+# sleep between annotate iterations, in 10*second
+INTERVAL="${2}"
+
+KUBECTL=$(which kubectl)
+ANNOTATION=""
+
+# allow container interrupts
+trap "{ exit 1; }" INT TERM
+
+while [ true ]; do
+  # get dir's mount point usage in MB
+  SIZE=$(df -P -BM "${DATA_DIR}" | tail -n 1 | awk '{print $3}'|sed 's/M//g')
+  # use negative values, the bigger is the disk usage the lower is the pod deletion cost
+  # thus the most "heavy" pod will be removed first
+  ANNOTATION="controller.kubernetes.io/pod-deletion-cost=-${SIZE}"
+  ${KUBECTL} annotate --overwrite=true pod "${MY_POD_NAME}" "${ANNOTATION}"
+  ret=$?
+  if [ ${ret} -eq 0 ];then
+    echo "$(date -Iseconds) Annotated pod ${MY_POD_NAME} with ${ANNOTATION}"
+  else
+    echo "$(date -Iseconds) Error annotating pod ${MY_POD_NAME} with ${ANNOTATION}"
+  fi
+  {{- if and .Values.autoScaleTrigger.enabled (eq .Values.controller "CloneSet") }}
+  ADDON_POD_NAME=$(${KUBECTL} get pods --namespace="${MY_POD_NAMESPACE}" --selector=bsc/role="auto-scale-trigger" --field-selector=spec.nodeName="${MY_NODE_NAME}" -o name)
+  ret=$?
+  if [ ${ret} -eq 0 ];then
+    ${KUBECTL} annotate --overwrite=true "${ADDON_POD_NAME}" "${ANNOTATION}"
+    ret0=$?
+    if [ ${ret0} -eq 0 ];then
+      echo "$(date -Iseconds) Annotated ${ADDON_POD_NAME} with ${ANNOTATION}"
+    else
+      echo "$(date -Iseconds) Error annotating ${ADDON_POD_NAME} with ${ANNOTATION}"
+    fi
+  fi
+  {{- end }}
+  # we need to sleep <short-delay> inside cycle to handle pod termination w/o delays
+  for i in $(seq 2 "${INTERVAL}");do sleep 10;done
+done

--- a/dysnix/bsc/templates/serviceaccount.yaml
+++ b/dysnix/bsc/templates/serviceaccount.yaml
@@ -9,3 +9,52 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- end }}
+{{- if or (and (eq .Values.controller "CloneSet") .Values.updatePodDeletionCost.enabled) .Values.autoScaleHelper.enabled }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Release.Name }}
+  labels: {{ include "bsc.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+  - apiGroups: ["apps"]
+    resources:
+      - statefulsets
+      - statefulsets/scale
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+  - apiGroups: ["apps.kruise.io"]
+    resources:
+      - clonesets
+      - clonesets/scale
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}
+  labels: {{ include "bsc.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "bsc.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ .Release.Name }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/dysnix/bsc/templates/statefulset.yaml
+++ b/dysnix/bsc/templates/statefulset.yaml
@@ -9,6 +9,10 @@ kind: CloneSet
 metadata:
   name: {{ include "bsc.fullname" . }}
   labels: {{ include "bsc.labels" . | nindent 4 }}
+  annotations:
+    {{- if .Values.autoScaleTrigger.enabled }}
+    additionalControllerName: {{ include "bsc.scaleTriggerName" . }}
+    {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }} # by default is 1
   updateStrategy:
@@ -243,7 +247,40 @@ spec:
               name: "{{ .Release.Name }}-gcs-creds-sync-to"
         volumeMounts:
           - name: bsc-pvc
-            mountPath: {{ .Values.rsyncd.bsc_path }}
+            mountPath: {{ .Values.bsc.base_path }}
+          - name: scripts
+            mountPath: /scripts
+      {{- end }}
+      {{- if and (eq .Values.controller "CloneSet") .Values.updatePodDeletionCost.enabled }}
+      - name: update-pod-deletion-cost
+        image: "{{ .Values.updatePodDeletionCost.image }}"
+        command:
+          - /bin/sh
+          - /scripts/update-pod-deletion-cost.sh
+          - "/data"
+          - "60"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        env:
+        - name: MY_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: MY_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        resources:
+        {{- toYaml .Values.updatePodDeletionCost.resources | nindent 10 }}
+        securityContext:
+        {{- toYaml .Values.updatePodDeletionCost.securityContext | nindent 10 }}
+        volumeMounts:
+          - name: bsc-pvc
+            mountPath: /data
+            readOnly: true
           - name: scripts
             mountPath: /scripts
       {{- end }}

--- a/dysnix/bsc/values.yaml
+++ b/dysnix/bsc/values.yaml
@@ -55,6 +55,34 @@ updateStrategy:
 # .... a lot more, check https://openkruise.io/docs/user-manuals/cloneset/#update-types
 podDeletionCost: 0
 
+# Additional controller to trigger cluster autoscaler to scale up
+# https://github.com/kubernetes/autoscaler/issues/2145
+# w/o this there will be no scale up with [local SSD PV enabled] BSC pods hanging in Pending forever
+# another option is to use hostPath volumes instead of PV & PVC
+autoScaleTrigger:
+  enabled: false
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              bsc/role: "auto-scale-trigger"
+          topologyKey: kubernetes.io/hostname
+  containers:
+  - name: main
+    command:
+      - /bin/sh
+      - -c
+      - sleep infinity
+    image: busybox
+    resources: {}
+#    securityContext:
+#      runAsGroup: 1001
+#      runAsUser: 1001
+autoScaleHelper:
+  enabled: false
+  image: dysnix/shell-operator:v0.0.2
+
 continent:
 # Don't use spaces or special chars
 bsc:
@@ -234,6 +262,15 @@ gcsCleanup:
   image: google/cloud-sdk:alpine
   rmlist: rmlist.txt
   rmlog: rmlog.txt
+# updates pod annotation controller.kubernetes.io/pod-deletion-cost
+updatePodDeletionCost:
+  enabled: false
+  image: dysnix/kubectl:v1.20
+  resources: {}
+  securityContext:
+    runAsGroup: 1001
+    runAsUser: 1001
+
 # cronjobs to initiate sync-to-gcs and prune via pod restart
 cronjobs:
   sync:


### PR DESCRIPTION
* enable nginx reply compression by default
* add update-pod-deletion-cost sidecar to use it with controlled scale down
* add one more controller (scale-trigger) to work-around local SSD PV [autoscaler issue](https://github.com/kubernetes/autoscaler/issues/2145). Another possible way is to switch from PV & PVC to hostPath volumes
* add scale-helper to propagate scaling from main controller to scale-trigger 
* various small fixes