### PR TITLE
[bsc] enable forced cleanup with init-from-gcs by default

### DIFF
--- a/dysnix/bsc/Chart.yaml
+++ b/dysnix/bsc/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: bsc
 description: Binance Smart Chain chart for Kubernetes
-version: "0.6.3"
+version: "0.6.4"
 appVersion: "v1.1.7"
 
 keywords:

--- a/dysnix/bsc/values.yaml
+++ b/dysnix/bsc/values.yaml
@@ -119,6 +119,7 @@ bsc:
     keyID: "AWS_ACCESS_KEY_ID"
     accessKey: "AWS_SECRET_ACCESS_KEY"
     indexUrl: "bucket/path/to/file"
+    fullResyncOnSrcUpdate: true
   syncToGCS:
     enabled: false
     image: peakcom/s5cmd:v1.4.0


### PR DESCRIPTION
We cannot stabilize init-from-gsc for now, thus we enforce full cleanup by default in case of source timestamp changes