### PR TITLE
[bsc] add support of controller scaling

### DIFF
--- a/dysnix/bsc/Chart.yaml
+++ b/dysnix/bsc/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: bsc
 description: Binance Smart Chain chart for Kubernetes
-version: "0.6.6"
+version: "0.6.7"
 appVersion: "v1.1.8"
 
 keywords:

--- a/dysnix/bsc/templates/cronjob.yaml
+++ b/dysnix/bsc/templates/cronjob.yaml
@@ -132,7 +132,7 @@ metadata:
   labels: {{ include "bsc.labels" . | nindent 4 }}
 spec:
   schedule: "{{ .Values.cronjobs.rotate.schedule }}"
-  successfulJobsHistoryLimit: 1
+  successfulJobsHistoryLimit: 0
   concurrencyPolicy: Forbid
   startingDeadlineSeconds: 300
   jobTemplate:

--- a/dysnix/bsc/templates/statefulset.yaml
+++ b/dysnix/bsc/templates/statefulset.yaml
@@ -14,7 +14,9 @@ metadata:
     additionalControllerName: {{ include "bsc.scaleTriggerName" . }}
     {{- end }}
 spec:
+  {{- if ge (.Values.replicaCount|int) 0 }}
   replicas: {{ .Values.replicaCount }} # by default is 1
+  {{- end }}
   updateStrategy:
     {{- toYaml .Values.updateStrategy | nindent 4 }}
   {{- if eq .Values.controller "StatefulSet" }}


### PR DESCRIPTION
Related to [this helm bug](https://github.com/helm/helm/issues/7090). We may use negative replicaCount to keep existing replicas during helm upgrade