### PR TITLE
[bsc] add prune-block init

### DIFF
--- a/dysnix/bsc/Chart.yaml
+++ b/dysnix/bsc/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: bsc
 description: Binance Smart Chain chart for Kubernetes
-version: "0.6.9"
+version: "0.6.10"
 appVersion: "v1.1.8"
 
 keywords:

--- a/dysnix/bsc/templates/configmap.yaml
+++ b/dysnix/bsc/templates/configmap.yaml
@@ -63,6 +63,8 @@ data:
     {{- include (print $.Template.BasePath "/scripts/_gcs_cleanup.tpl") . | nindent 4 }}
   prune.sh: |-
     {{- include (print $.Template.BasePath "/scripts/_prune.tpl") . | nindent 4 }}
+  prune_block.sh: |-
+    {{- include (print $.Template.BasePath "/scripts/_prune_block.tpl") . | nindent 4 }}
   cron.sh: |-
     {{- include (print $.Template.BasePath "/scripts/_cron.tpl") . | nindent 4 }}
   update-pod-deletion-cost.sh: |-

--- a/dysnix/bsc/templates/scripts/_prune_block.tpl
+++ b/dysnix/bsc/templates/scripts/_prune_block.tpl
@@ -1,0 +1,28 @@
+#!/usr/bin/env sh
+
+# script performs BSC block prune from ancientDB, removing [unneeded in some cases] historical blocks
+# good use case is a bootnode w/o RPC
+# block prune should speed up node in runtime as well as allow to use less disk space
+# after block prune the node will not be able to serve RPC on pruned blocks
+# Around last 90000 blocks are kept in the node state before moving on to ancientDB
+
+set -x
+
+DATA_DIR="{{ .Values.bsc.base_path }}"
+
+GETH=/usr/local/bin/geth
+# how much recent blocks do we need to keep. Default 0 means we clean up ancientDB completely
+BLOCKS_RESERVED=${1:-0}
+
+ret=0
+  # background logging
+  tail -F "${DATA_DIR}/bsc.log" &
+  # prune-block will turn our full node into light one actually
+  $GETH --config=/config/config.toml --datadir=${DATA_DIR} --datadir.ancient=${DATA_DIR}/geth/chaindata/ancient --cache {{ .Values.bsc.cache }} snapshot prune-block --block-amount-reserved=${BLOCKS_RESERVED}
+  ret=$?
+  if [ "${ret}" -eq "0" ];then
+    # update timestamp
+    date +%s > "${DATA_DIR}/block_prune_timestamp"
+  fi
+
+exit $ret

--- a/dysnix/bsc/templates/statefulset.yaml
+++ b/dysnix/bsc/templates/statefulset.yaml
@@ -455,6 +455,21 @@ spec:
           - name: generated-bsc-config
             mountPath: /config
       {{- end }}
+      {{- if .Values.bsc.pruneBlock.enabled }}
+      - name: bsc-prune-block
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: IfNotPresent
+        command:
+          - /bin/sh
+          - /scripts/prune_block.sh
+        volumeMounts:
+          - name: bsc-pvc
+            mountPath: {{ .Values.bsc.base_path }}
+          - name: scripts
+            mountPath: /scripts
+          - name: generated-bsc-config
+            mountPath: /config
+      {{- end }}
       volumes:
         - name: bsc-config
           configMap:

--- a/dysnix/bsc/values.yaml
+++ b/dysnix/bsc/values.yaml
@@ -133,6 +133,8 @@ bsc:
     baseUrl: "bucket/path/to/dir"
   prune:
     enabled: false
+  pruneBlock:
+    enabled: false
   forceInitFromSnapshot: false
   snapshotUrl:
   snapshotRsyncUrl: "rsync://192.168.8.4/snapshot/geth/node/geth"


### PR DESCRIPTION
[prune-block](https://github.com/bnb-chain/bsc/pull/543) allows to save space if you don't need historical data. May be useful with bootnodes w/o RPC.