### PR TITLE
[nifi-registry] added bundle provider configuration

### DIFF
--- a/dysnix/nifi-registry/Chart.yaml
+++ b/dysnix/nifi-registry/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/dysnix/nifi-registry/templates/statefulset.yaml
+++ b/dysnix/nifi-registry/templates/statefulset.yaml
@@ -218,7 +218,7 @@ spec:
           {{- if eq .Values.bundleProvider.s3.credentialsProvider "DEFAULT_CHAIN" }}
           envFrom:
             - secretRef: 
-              name: {{ .Values.bundleProvider.s3.accessSecret.name }}
+                name: {{ .Values.bundleProvider.s3.accessSecret.name }}
           {{- end }}
           env:
           {{- if .Values.bundleProvider.s3.enabled }}

--- a/dysnix/nifi-registry/templates/statefulset.yaml
+++ b/dysnix/nifi-registry/templates/statefulset.yaml
@@ -215,7 +215,37 @@ spec:
               containerPort: 18080
               protocol: TCP
           {{/* if .Values.security.enabled */}}{{ end }}
+          {{- if eq .Values.extensionPersistence.s3.credentialsProvider "DEFAULT_CHAIN" }}
+          envFrom:
+            - secretRef: 
+              name: {{ .Values.extensionPersistence.s3.accessSecret.name }}
+          {{- end }}
           env:
+          {{- if .Values.bundleProvider.s3.enabled }}
+            - name: NIFI_REGISTRY_BUNDLE_PROVIDER
+              value: s3
+            - name: NIFI_REGISTRY_S3_REGION
+              value: {{ .Values.bundleProvider.s3.region }}
+            - name: NIFI_REGISTRY_S3_BUCKET_NAME
+              value: {{ .Values.bundleProvider.s3.bucketName }}
+            - name: NIFI_REGISTRY_S3_KEY_PREFIX
+              value: {{ .Values.bundleProvider.s3.keyPrefix }}
+            - name: NIFI_REGISTRY_S3_CREDENTIALS_PROVIDER
+              value: {{ .Values.bundleProvider.s3.credentialsProvider }}
+              # The below access key and secret access key are only used if the credential provider is STATIC
+            - name: NIFI_REGISTRY_S3_ACCESS_KEY
+              value: {{ .Values.bundleProvider.s3.accessKey }}
+            - name: NIFI_REGISTRY_S3_SECRET_ACCESS_KEY
+              value: {{ .Values.bundleProvider.s3.secretAccessKey }}
+            - name: NIFI_REGISTRY_S3_ENDPOINT_URL
+              value: {{ .Values.bundleProvider.s3.endpoint }}
+          {{- end }}
+          {{- if .Values.bundleProvider.file.enabled }}
+            - name: NIFI_REGISTRY_BUNDLE_PROVIDER
+              value: file
+            - name: NIFI_REGISTRY_BUNDLE_STORAGE_DIR
+              value: {{ .Values.bundleProvider.file.storageDirectory }}
+          {{- end }}
           {{- if .Values.flowProvider.git.enabled }}
             - name: NIFI_REGISTRY_FLOW_PROVIDER
               value: git

--- a/dysnix/nifi-registry/templates/statefulset.yaml
+++ b/dysnix/nifi-registry/templates/statefulset.yaml
@@ -215,10 +215,10 @@ spec:
               containerPort: 18080
               protocol: TCP
           {{/* if .Values.security.enabled */}}{{ end }}
-          {{- if eq .Values.extensionPersistence.s3.credentialsProvider "DEFAULT_CHAIN" }}
+          {{- if eq .Values.bundleProvider.s3.credentialsProvider "DEFAULT_CHAIN" }}
           envFrom:
             - secretRef: 
-              name: {{ .Values.extensionPersistence.s3.accessSecret.name }}
+              name: {{ .Values.bundleProvider.s3.accessSecret.name }}
           {{- end }}
           env:
           {{- if .Values.bundleProvider.s3.enabled }}

--- a/dysnix/nifi-registry/values.yaml
+++ b/dysnix/nifi-registry/values.yaml
@@ -102,7 +102,7 @@ bundleProvider:
     bucketName: nifi-registry-bucket
     keyPrefix: ""
     # -- valid credentialProvider values are STATIC, DEFAULT_CHAIN.
-    credentialsProvider: DEFAULT_CHAIN
+    credentialsProvider: STATIC
     # -- If credentialsProvider is STATIC, must specify access key and secret access key
     accessKey: ""
     secretAccessKey: ""

--- a/dysnix/nifi-registry/values.yaml
+++ b/dysnix/nifi-registry/values.yaml
@@ -95,6 +95,29 @@ tolerations: []
 
 affinity: {}
 
+bundleProvider:
+  s3:
+    enabled: false
+    region: us-east-1
+    bucketName: nifi-registry-bucket
+    keyPrefix: ""
+    # -- valid credentialProvider values are STATIC, DEFAULT_CHAIN.
+    credentialsProvider: DEFAULT_CHAIN
+    # -- If credentialsProvider is STATIC, must specify access key and secret access key
+    accessKey: ""
+    secretAccessKey: ""
+    # -- If credentialsProvider is DEFAULT_CHAIN, configure a secret containing AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY to mount into nifi registry pod env variables
+    accessSecret:
+      name: nifi-registry-s3-creds
+    endpoint: s3://s3.us-east-1.amazonaws.com
+
+  fileSystem:
+    enabled: true
+    # -- the path in the running pod where the git repo will be cloned into
+    # either absolute or relative to the container working directory, which is NIFI_REGISTRY_HOME
+    # If you elect to use a non-default location, you must also update the property associated.
+    storageDirectory: ./extension_bundles
+
 flowProvider:
   git:
     enabled: false

--- a/dysnix/nifi-registry/values.yaml
+++ b/dysnix/nifi-registry/values.yaml
@@ -111,7 +111,7 @@ bundleProvider:
       name: nifi-registry-s3-creds
     endpoint: s3://s3.us-east-1.amazonaws.com
 
-  fileSystem:
+  file:
     enabled: true
     # -- the path in the running pod where the git repo will be cloned into
     # either absolute or relative to the container working directory, which is NIFI_REGISTRY_HOME


### PR DESCRIPTION
This PR adds the ability to configure NiFi Registry's bundle provider per the following sources:

- https://github.com/apache/nifi/blob/main/nifi-registry/nifi-registry-core/nifi-registry-docker/dockerhub/sh/update_bundle_provider.sh
- https://nifi.apache.org/docs/nifi-registry-docs/html/administration-guide.html#bundle-persistence-providers