### PR TITLE
[nifi-registry] bump NiFi zookeeper chart version

### DIFF
--- a/.github/workflows/nifi-registry-tests.yaml
+++ b/.github/workflows/nifi-registry-tests.yaml
@@ -140,7 +140,7 @@ jobs:
           # CHART_UPSTREAM_CHECKOUT="1.0.4"
           # Replace the below with above when https://github.com/cetic/helm-nifi/pull/218 is merged
           CHART_UPSTREAM_REPO="https://github.com/wknickless/helm-nifi.git"
-          CHART_UPSTREAM_CHECKOUT="7f4dda59f1aa4f9918018d6c8dd5ec6fc3da9a28"
+          CHART_UPSTREAM_CHECKOUT="62b602486507151da92cf889e59bef431952a03b"
           git clone "$CHART_UPSTREAM_REPO" helm-nifi
           cd helm-nifi
           git checkout "$CHART_UPSTREAM_CHECKOUT"

--- a/.github/workflows/nifi-registry-tests.yaml
+++ b/.github/workflows/nifi-registry-tests.yaml
@@ -130,27 +130,14 @@ jobs:
           tests/02-ssh-keygen.sh
           kubectl apply -f tests/02-git-repository.yaml
           kubectl rollout status --timeout=20m --watch statefulset/git
-      - name: Get NiFi Helm Chart
-        run: |
-          set -ex
-          cd $HOME
-          mkdir -p src
-          cd src
-          # CHART_UPSTREAM_REPO="https://github.com/cetic/helm-nifi.git"
-          # CHART_UPSTREAM_CHECKOUT="1.0.4"
-          # Replace the below with above when https://github.com/cetic/helm-nifi/pull/218 is merged
-          CHART_UPSTREAM_REPO="https://github.com/wknickless/helm-nifi.git"
-          CHART_UPSTREAM_CHECKOUT="62b602486507151da92cf889e59bef431952a03b"
-          git clone "$CHART_UPSTREAM_REPO" helm-nifi
-          cd helm-nifi
-          git checkout "$CHART_UPSTREAM_CHECKOUT"
-          helm dep update
       - name: Install Nifi Registry and NiFi
         run: |
           set -ex
           cd dysnix/nifi-registry
           helm install nifi-registry . -f tests/02-registry-values.yaml
-          helm install nifi $HOME/src/helm-nifi -f tests/02-nifi-values.yaml
+          helm repo add cetic https://cetic.github.io/helm-charts
+          helm repo update
+          helm install nifi cetic/nifi --version 1.1.0 -f tests/02-nifi-values.yaml
           kubectl rollout status --timeout=20m --watch statefulset/nifi-registry
           kubectl rollout status --timeout=20m --watch statefulset/nifi
       - name: Create NiFi Registry Bucket

--- a/.github/workflows/nifi-registry-tests.yaml
+++ b/.github/workflows/nifi-registry-tests.yaml
@@ -1,12 +1,12 @@
 name: NiFi Registry
 
 on:
-  repository_dispatch:
-    types: [disabled-until-a-soultion-suggested]
-  # push:
-  #   paths:
-  #     - '.github/workflows/nifi-registry-tests.yaml'
-  #     - 'dysnix/nifi-registry/**'
+  # repository_dispatch:
+  #   types: [disabled-until-a-soultion-suggested]
+  push:
+    paths:
+      - '.github/workflows/nifi-registry-tests.yaml'
+      - 'dysnix/nifi-registry/**'
 
 jobs:
   test-cert-manager:

--- a/dysnix/nifi-registry/Chart.yaml
+++ b/dysnix/nifi-registry/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.0
+version: 1.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/dysnix/nifi-registry/tests/02-nifi-values.yaml
+++ b/dysnix/nifi-registry/tests/02-nifi-values.yaml
@@ -1,3 +1,6 @@
+image:
+  tag: "1.16.3"
+
 zookeeper:
   enabled: true
 

--- a/dysnix/nifi-registry/tests/02-registry-values.yaml
+++ b/dysnix/nifi-registry/tests/02-registry-values.yaml
@@ -1,5 +1,5 @@
 image:
-  tag: "1.16.1"
+  tag: "1.16.3"
 
 service:
   type: ClusterIP


### PR DESCRIPTION
Hi @dennybaa it's unfortunate that the NiFi Registry end-to-end test cost you time when it broke as you were merging https://github.com/dysnix/charts/pull/201 .  The reason the test broke was because the NiFi Helm chart referenced a version of the Zookeeper Helm chart that no longer existed (see https://github.com/cetic/helm-nifi/issues/256).  I fixed that with an update to https://github.com/cetic/helm-nifi/pull/218 and this PR references the new tip of that branch.

However, having this end-to-end test has already saved us all time.  For example, the commit https://github.com/dysnix/charts/commit/500536e89b98e422c2255fb465a53cb506be391e was in https://github.com/dysnix/charts/pull/201 because the test failed (see https://github.com/michael81877/dysnix-charts/runs/6572915433?check_suite_focus=true), so the author saw and fixed the problem before it got to you as a completed PR.

Back in November 2021 I sent you https://github.com/dysnix/charts/commit/888ae5e67a92d555afd636bcca065ec20ef52016 as part of https://github.com/dysnix/charts/pull/112 which fixed an issue that broke NiFi Registry's ability to actually push flow changes via SSH to the Git back end.  (Prior to the fix NiFi Registry could clone the Git repository but couldn't actually push changes back into Git.)

I've had to send duplicate PRs when a different Helm chart maintainer accepted changes that broke things I'd sent fixes in already and that we depend on.  In production we use NiFi Registry with OIDC authentication, cert-manager, and a Git repository accessed via SSH.  That's why we went to the trouble of creating a test that sets up all the infrastructure to ensure NiFi can push its flow changes all the way via NiFi Registry and SSH to a Git server.  More generally, there's nothing in the chart test that we don't use in production.  We're not trying to test all the use cases for NiFi or NiFi Registry; just the things in the NiFi Registry Helm chart that we depend on.

Does this help?  Do you have any ideas or guidance or thoughts about how we might simplify the test so we ensure chart-specific fixes stay fixed and it's not so fragile it's likely to waste your time in the future?