### PR TITLE
[nifi-registry] Allow configuring git flow repository without full security

### DIFF
--- a/dysnix/nifi-registry/templates/statefulset.yaml
+++ b/dysnix/nifi-registry/templates/statefulset.yaml
@@ -191,7 +191,10 @@ spec:
               prop_replace 'nifi.registry.web.http.host'   ''
               prop_replace 'nifi.registry.web.https.port'  "${NIFI_REGISTRY_WEB_HTTPS_PORT:-18443}"
               prop_replace 'nifi.registry.web.https.host'  "${NIFI_REGISTRY_WEB_HTTPS_HOST:-$HOSTNAME}"
-          {{- /* if .Values.security.enabled */}}{{ end }}
+          {{- else if .Values.flowProvider.git.enabled }}
+              scripts_dir='/opt/nifi-registry/scripts'
+              . "${scripts_dir}/update_flow_provider.sh"
+          {{- /* if .Values.security.enabled */}}{{- end }}
 
               # Log everything to the console, not to files
               xmlstarlet ed --inplace --delete "//configuration/logger/appender-ref[@ref='CONSOLE']" "${NIFI_REGISTRY_HOME}/conf/logback.xml"


### PR DESCRIPTION
We have a use case where git-backed flows are desirable but access control is handled via other means. This was the bare minimum change we needed to make to get things working.