### PR TITLE
[ProxySQL] Add healthchek sidecar for cluster checks

### DIFF
--- a/dysnix/proxysql/Chart.yaml
+++ b/dysnix/proxysql/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "2.4.4"
 description: ProxySQL Helm chart for Kubernetes
 name: proxysql
-version: 0.4.1
+version: 0.8.0
 home: https://www.proxysql.com/
 sources:
   - https://github.com/dysnix/charts

--- a/dysnix/proxysql/Chart.yaml
+++ b/dysnix/proxysql/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "2.4.4"
 description: ProxySQL Helm chart for Kubernetes
 name: proxysql
-version: 0.8.0
+version: 0.8.1
 home: https://www.proxysql.com/
 sources:
   - https://github.com/dysnix/charts

--- a/dysnix/proxysql/files/proxysql_cluster_healthcheck.sh
+++ b/dysnix/proxysql/files/proxysql_cluster_healthcheck.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+set -u
+
+# Set the database connection variables
+DB_USER="${DB_USER:-monitor}"
+DB_HOST="${DB_HOST:-127.0.0.1}"
+DB_PORT="${DB_PORT:-6032}"
+
+PROXYSQL_DIFF_CHECK_LIMIT=${PROXYSQL_DIFF_CHECK_LIMIT:-10}
+PROXYSQL_KILL_IF_HEALTCHECK_FAILED=${PROXYSQL_KILL_IF_HEALTCHECK_FAILED:-true}
+
+export MYSQL_PWD="${DB_PASS:-monitor}"
+
+function mysql_cli() {
+  mysql -u ${DB_USER} -h ${DB_HOST} -P ${DB_PORT} --skip-column-names --batch --ssl-mode=DISABLED -e "$1"
+}
+
+function run_diff_check_count() {
+  DIFF_CHECK_COUNT=$(mysql_cli "SELECT COUNT(diff_check) FROM stats_proxysql_servers_checksums WHERE diff_check > ${PROXYSQL_DIFF_CHECK_LIMIT};")
+
+  if [[ "${DIFF_CHECK_COUNT}" -lt "${PROXYSQL_DIFF_CHECK_LIMIT}" ]]; then
+    echo "[$(date -Ins)] ProxySQL Cluster diff_check OK. diff_check < ${PROXYSQL_DIFF_CHECK_LIMIT}"
+  else
+    RESULT=$(mysql_cli "SELECT hostname, port, name, version, FROM_UNIXTIME(epoch) epoch, checksum, FROM_UNIXTIME(changed_at) changed_at, FROM_UNIXTIME(updated_at) updated_at, diff_check, DATETIME('NOW') FROM stats_proxysql_servers_checksums WHERE diff_check > ${PROXYSQL_DIFF_CHECK_LIMIT} ORDER BY name;")
+    echo "[$(date -Ins)] ProxySQL Cluster diff_check WARNING. diff_check >= ${PROXYSQL_DIFF_CHECK_LIMIT}"
+    echo "${RESULT}"
+    if [[ "${PROXYSQL_KILL_IF_HEALTCHECK_FAILED}" == "true" ]]; then
+      echo "[$(date -Ins)] Terminating proxysql process..."
+      kill -s SIGTERM "$(pidof proxysql)"
+    fi
+    echo "[$(date -Ins)] ProxySQL health check exiting..."
+    exit 1
+  fi
+}
+
+echo "[$(date -Ins)] ProxySQL health check start..."
+while true; do
+  run_diff_check_count
+  sleep $[ ( $RANDOM % 6 )  + 3 ]s
+done

--- a/dysnix/proxysql/templates/configmap-healthcheck.yaml
+++ b/dysnix/proxysql/templates/configmap-healthcheck.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.proxysql_cluster.healthcheck.sidecar.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "proxysql.fullname" . }}-healthcheck
+  labels:
+    {{- include "proxysql.labels" . | nindent 4 }}
+data: 
+  DB_USER: {{ .Values.proxysql_cluster.healthcheck.sidecar.config.psql_user | quote }}
+  DB_HOST: {{ .Values.proxysql_cluster.healthcheck.sidecar.config.psql_host | quote }}
+  DB_PORT: {{ .Values.proxysql_cluster.healthcheck.sidecar.config.psql_host_port | quote }}
+  PROXYSQL_DIFF_CHECK_LIMIT: {{ .Values.proxysql_cluster.healthcheck.sidecar.config.diff_check_limit | quote }}
+  PROXYSQL_KILL_IF_HEALTCHECK_FAILED: {{ .Values.proxysql_cluster.healthcheck.sidecar.config.kill_if_healthcheck_failed | quote }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "proxysql.fullname" . }}-healthcheck-scripts
+  labels:
+    {{- include "proxysql.labels" . | nindent 4 }}
+data:
+  proxysql_cluster_healthcheck.sh: |
+    {{- tpl (.Files.Get "files/proxysql_cluster_healthcheck.sh") . | nindent 4 }}
+{{- end }}

--- a/dysnix/proxysql/templates/configmap.yaml
+++ b/dysnix/proxysql/templates/configmap.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "proxysql.fullname" . }}
+  labels:
+    {{- include "proxysql.labels" . | nindent 4 }}
 data: 
   proxysql.cnf: |
     {{- tpl (.Files.Get "files/proxysql.cnf") . | nindent 4 }}

--- a/dysnix/proxysql/templates/daemonset.yaml
+++ b/dysnix/proxysql/templates/daemonset.yaml
@@ -31,6 +31,7 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       dnsPolicy: ClusterFirst
+      shareProcessNamespace: true
       containers:
         - name: {{ .Chart.Name }}
           command:
@@ -102,9 +103,29 @@ spec:
           image: {{ .Values.debug.sidecar.image }}
           command:
             {{- toYaml .Values.debug.sidecar.command | nindent 14 }}
+          {{- with .Values.debug.sidecar.securityContext }}
           securityContext:
-            runAsGroup: 1001
-            runAsUser: 1001
+            {{- toYaml .| nindent 12 }}
+          {{- end }}
+        {{- end }}
+        {{- if and .Values.proxysql_cluster.enabled .Values.proxysql_cluster.healthcheck.sidecar.enabled }}
+        - name: healthcheck
+          image: {{ .Values.proxysql_cluster.healthcheck.sidecar.image }}
+          command:
+            {{- toYaml .Values.proxysql_cluster.healthcheck.sidecar.command | nindent 14 }}
+          envFrom:
+            - configMapRef:
+                name: '{{ include "proxysql.fullname" . }}-healthcheck'
+            - secretRef:
+                name: '{{ include "proxysql.fullname" . }}-healthcheck'
+          volumeMounts:
+            - name: healthcheck-scripts
+              mountPath: /usr/local/bin/proxysql_cluster_healthcheck.sh
+              subPath: proxysql_cluster_healthcheck.sh
+          {{- with .Values.proxysql_cluster.healthcheck.sidecar.securityContext }}
+          securityContext:
+            {{- toYaml .| nindent 12 }}
+          {{- end }}
         {{- end }}
       {{- with (default .Values.nodeSelector .Values.proxysql_cluster.satellite.daemonset.nodeSelector) }}
       nodeSelector:
@@ -135,4 +156,11 @@ spec:
             secretName: {{ . }}
             defaultMode: 0640
         {{- end }}
+        - name: healthcheck-scripts
+          configMap:
+            name: {{ include "proxysql.fullname" . }}-healthcheck-scripts
+            items:
+              - key: proxysql_cluster_healthcheck.sh
+                path: proxysql_cluster_healthcheck.sh
+                mode: 0777
 {{- end }}

--- a/dysnix/proxysql/templates/deployment.yaml
+++ b/dysnix/proxysql/templates/deployment.yaml
@@ -32,6 +32,7 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       dnsPolicy: ClusterFirst
+      shareProcessNamespace: true
       containers:
         - name: {{ .Chart.Name }}
           command:
@@ -103,9 +104,29 @@ spec:
           image: {{ .Values.debug.sidecar.image }}
           command:
             {{- toYaml .Values.debug.sidecar.command | nindent 14 }}
+          {{- with .Values.debug.sidecar.securityContext }}
           securityContext:
-            runAsGroup: 1001
-            runAsUser: 1001
+            {{- toYaml .| nindent 12 }}
+          {{- end }}
+        {{- end }}
+        {{- if and .Values.proxysql_cluster.enabled .Values.proxysql_cluster.healthcheck.sidecar.enabled }}
+        - name: healthcheck
+          image: {{ .Values.proxysql_cluster.healthcheck.sidecar.image }}
+          command:
+            {{- toYaml .Values.proxysql_cluster.healthcheck.sidecar.command | nindent 14 }}
+          envFrom:
+            - configMapRef:
+                name: '{{ include "proxysql.fullname" . }}-healthcheck'
+            - secretRef:
+                name: '{{ include "proxysql.fullname" . }}-healthcheck'
+          volumeMounts:
+            - name: healthcheck-scripts
+              mountPath: /usr/local/bin/proxysql_cluster_healthcheck.sh
+              subPath: proxysql_cluster_healthcheck.sh
+          {{- with .Values.proxysql_cluster.healthcheck.sidecar.securityContext }}
+          securityContext:
+            {{- toYaml .| nindent 12 }}
+          {{- end }}
         {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
@@ -136,4 +157,11 @@ spec:
             secretName: {{ . }}
             defaultMode: 0640
         {{- end }}
+        - name: healthcheck-scripts
+          configMap:
+            name: {{ include "proxysql.fullname" . }}-healthcheck-scripts
+            items:
+              - key: proxysql_cluster_healthcheck.sh
+                path: proxysql_cluster_healthcheck.sh
+                mode: 0777
 {{- end }}

--- a/dysnix/proxysql/templates/secret-healthcheck.yaml
+++ b/dysnix/proxysql/templates/secret-healthcheck.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.proxysql_cluster.healthcheck.sidecar.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "proxysql.fullname" . }}-healthcheck
+  labels:
+    {{- include "proxysql.labels" . | nindent 4 }}
+data:
+  DB_PASS: {{ .Values.proxysql_cluster.healthcheck.sidecar.config.psql_pass | default "" | b64enc | quote }}
+{{- end }}

--- a/dysnix/proxysql/templates/statefullset.yaml
+++ b/dysnix/proxysql/templates/statefullset.yaml
@@ -33,6 +33,7 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       dnsPolicy: ClusterFirst
+      shareProcessNamespace: true
       containers:
         - name: {{ .Chart.Name }}
           command:
@@ -104,9 +105,29 @@ spec:
           image: {{ .Values.debug.sidecar.image }}
           command:
             {{- toYaml .Values.debug.sidecar.command | nindent 14 }}
+          {{- with .Values.debug.sidecar.securityContext }}
           securityContext:
-            runAsGroup: 1001
-            runAsUser: 1001
+            {{- toYaml .| nindent 12 }}
+          {{- end }}
+        {{- end }}
+        {{- if and .Values.proxysql_cluster.enabled .Values.proxysql_cluster.healthcheck.sidecar.enabled }}
+        - name: healthcheck
+          image: {{ .Values.proxysql_cluster.healthcheck.sidecar.image }}
+          command:
+            {{- toYaml .Values.proxysql_cluster.healthcheck.sidecar.command | nindent 14 }}
+          envFrom:
+            - configMapRef:
+                name: '{{ include "proxysql.fullname" . }}-healthcheck'
+            - secretRef:
+                name: '{{ include "proxysql.fullname" . }}-healthcheck'
+          volumeMounts:
+            - name: healthcheck-scripts
+              mountPath: /usr/local/bin/proxysql_cluster_healthcheck.sh
+              subPath: proxysql_cluster_healthcheck.sh
+          {{- with .Values.proxysql_cluster.healthcheck.sidecar.securityContext }}
+          securityContext:
+            {{- toYaml .| nindent 12 }}
+          {{- end }}
         {{- end }}
       {{- with (default .Values.nodeSelector .Values.proxysql_cluster.core.statefullset.nodeSelector) }}
       nodeSelector:
@@ -137,4 +158,11 @@ spec:
             secretName: {{ . }}
             defaultMode: 0640
         {{- end }}
+        - name: healthcheck-scripts
+          configMap:
+            name: {{ include "proxysql.fullname" . }}-healthcheck-scripts
+            items:
+              - key: proxysql_cluster_healthcheck.sh
+                path: proxysql_cluster_healthcheck.sh
+                mode: 0777
 {{- end }}

--- a/dysnix/proxysql/values.yaml
+++ b/dysnix/proxysql/values.yaml
@@ -325,15 +325,37 @@ proxysql_cluster:
     #    cpu: 100m
     #    memory: 128Mi
 
+  healthcheck:
+    sidecar:
+      # inject a healthcheck sidecar container to all proxysql clustering Pods
+      enabled: false
+      image: mysql:debian
+      command:
+        - /usr/local/bin/proxysql_cluster_healthcheck.sh
+      config:
+        psql_user: monitor
+        psql_pass: monitor
+        psql_host: 127.0.0.1 # The listening core host/pod
+        psql_host_port: 6032 # The admin port
+
+        diff_check_limit: 10 # How many diff_check errors are tolerated before the healthcheck fails
+        kill_if_healthcheck_failed: true  # Kill proxysql daemon if the healthcheck fails the test
+      securityContext:
+        runAsUser: 999
+        runAsGroup: 999
+
 # Enable debugging container along the proxysql instance
 #   It may be usefull to access the proxysql admin interface locally to debug issues
 debug:
   sidecar:
     # inject a debug sidecar container to all proxysql Pods
     enabled: false
-    image: mysql
+    image: mysql:debian
     command:
       - /bin/sleep
       - infinity
+    securityContext:
+      runAsUser: 999
+      runAsGroup: 999
 
 terminationGracePeriodSeconds: 60

--- a/dysnix/proxysql/values.yaml
+++ b/dysnix/proxysql/values.yaml
@@ -335,10 +335,10 @@ proxysql_cluster:
       config:
         psql_user: monitor
         psql_pass: monitor
-        psql_host: 127.0.0.1 # The listening core host/pod
-        psql_host_port: 6032 # The admin port
+        psql_host: 127.0.0.1  # The listening core host/pod
+        psql_host_port: 6032  # The admin port
 
-        diff_check_limit: 10 # How many diff_check errors are tolerated before the healthcheck fails
+        diff_check_limit: 10  # How many diff_check errors are tolerated before the healthcheck fails
         kill_if_healthcheck_failed: true  # Kill proxysql daemon if the healthcheck fails the test
       securityContext:
         runAsUser: 999


### PR DESCRIPTION
And if selected, restart the proxysql daemon container.
This healthchecks are useful in a proxysql-cluster environment to avoid syncing issues, when the cluster config differs after a long time.