### PR TITLE
fix: nifi-registry git clone in v0.8.0

### DIFF
--- a/dysnix/nifi-registry/templates/statefulset.yaml
+++ b/dysnix/nifi-registry/templates/statefulset.yaml
@@ -194,6 +194,7 @@ spec:
           {{- else if .Values.flowProvider.git.enabled }}
               scripts_dir='/opt/nifi-registry/scripts'
               . "${scripts_dir}/update_flow_provider.sh"
+              xmlstarlet ed --inplace --subnode "/providers/flowPersistenceProvider" --type elem -n property -v "${NIFI_REGISTRY_GIT_REPO:-}" -i \$prev --type attr -n name -v "Remote Clone Repository" "${NIFI_REGISTRY_HOME}/conf/providers.xml"
           {{- /* if .Values.security.enabled */}}{{- end }}
 
               # Log everything to the console, not to files

--- a/dysnix/nifi-registry/templates/statefulset.yaml
+++ b/dysnix/nifi-registry/templates/statefulset.yaml
@@ -258,7 +258,14 @@ spec:
             - name: NIFI_REGISTRY_GIT_USER
               value: {{ .Values.flowProvider.git.user }}
             - name: NIFI_REGISTRY_GIT_PASSWORD
+            {{- if .Values.flowProvider.git.passwordSecretName }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.flowProvider.git.passwordSecretName }}
+                  key: {{ .Values.flowProvider.git.passwordSecretKey }}
+            {{- else }}
               value: {{ .Values.flowProvider.git.password }}
+            {{- end }}
             - name: NIFI_REGISTRY_GIT_REPO
               value: {{ .Values.flowProvider.git.url }}
           {{- end }}

--- a/dysnix/nifi-registry/values.yaml
+++ b/dysnix/nifi-registry/values.yaml
@@ -129,6 +129,9 @@ flowProvider:
     user:
     # Sets NIFI_REGISTRY_GIT_PASSWORD for update_flow_provider.sh
     password:
+    # passwordSecret(Name|Key) is the name and key of the k8s secret holding the password (can be used instead of password)
+    # passwordSecretName:
+    # passwordSecretKey:
     # Global Git configuration See https://git-scm.com/docs/git-config for more details.
     config:
       enabled: false


### PR DESCRIPTION
Between nifi-registry v0.8.0 and v1.19.1 this statement was added in `/opt/nifi-registry/scripts/update_flow_provider.sh`:

```
	if [ ! -z "$NIFI_REGISTRY_GIT_REPO" ]; then
		add_property "Remote Clone Repository" "${NIFI_REGISTRY_GIT_REPO:-}"
	fi
```
This commit adds that statement so the `git clone` will work with v0.8.0.
It should be noted that `git clone` does not [currently work with ssh authentication](https://issues.apache.org/jira/browse/NIFI-8867).

I also added the option to use a k8s secret for the git password. 