### PR TITLE
[raw] fix missing whitespace after yaml separator

### DIFF
--- a/dysnix/raw/Chart.yaml
+++ b/dysnix/raw/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A place for all the Kubernetes resources which don't already have a home
 name: raw
-version: v0.3.1
+version: v0.3.2
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/dysnix/charts/blob/master/dysnix/raw
 keywords:

--- a/dysnix/raw/templates/resources.yaml
+++ b/dysnix/raw/templates/resources.yaml
@@ -27,10 +27,10 @@
 
 {{- range $resources }}
 ---
-{{- merge . $metadata | toYaml }}
+{{ merge . $metadata | toYaml }}
 {{- end }}
 
 {{- range $templates }}
 ---
-{{- merge (tpl . $ | fromYaml) $metadata | toYaml }}
+{{ merge (tpl . $ | fromYaml) $metadata | toYaml }}
 {{- end }}


### PR DESCRIPTION
We're having errors while running `helm lint`:
```
[ERROR] templates/resources.yaml: unable to parse YAML: invalid Yaml document separator:
```

This PR adds missing whitespace after yaml separator when creating multiple resources.