### PR TITLE
SWP-101022   [ProxySQL helm] use correct hostname in proxysql.cnf

### DIFF
--- a/dysnix/proxysql/Chart.yaml
+++ b/dysnix/proxysql/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "2.4.4"
 description: ProxySQL Helm chart for Kubernetes
 name: proxysql
-version: 0.10.1
+version: 0.10.2-splashthat-rc1
 home: https://www.proxysql.com/
 sources:
   - https://github.com/dysnix/charts

--- a/dysnix/proxysql/Chart.yaml
+++ b/dysnix/proxysql/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "2.4.4"
 description: ProxySQL Helm chart for Kubernetes
 name: proxysql
-version: 0.10.2-splashthat-rc1
+version: 0.10.2-splashthat-rc2
 home: https://www.proxysql.com/
 sources:
   - https://github.com/dysnix/charts

--- a/dysnix/proxysql/Chart.yaml
+++ b/dysnix/proxysql/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "2.4.4"
 description: ProxySQL Helm chart for Kubernetes
 name: proxysql
-version: 0.10.2-splashthat-rc3
+version: 0.10.2-splashthat-rc4
 home: https://www.proxysql.com/
 sources:
   - https://github.com/dysnix/charts

--- a/dysnix/proxysql/Chart.yaml
+++ b/dysnix/proxysql/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "2.4.4"
 description: ProxySQL Helm chart for Kubernetes
 name: proxysql
-version: 0.10.2-splashthat-rc2
+version: 0.10.2-splashthat-rc3
 home: https://www.proxysql.com/
 sources:
   - https://github.com/dysnix/charts

--- a/dysnix/proxysql/README.md
+++ b/dysnix/proxysql/README.md
@@ -52,6 +52,8 @@ The following table lists the configurable parameters of the ProxySQL chart and 
 | `image.tag`                                 | ProxySQL Image tag                                   | `2.0.9`                                                          |
 | `image.pullPolicy`                          | ProxySQL image pull policy                           | `IfNotPresent`                                                   |
 | `image.pullSecrets`                         | Specify docker-registry secret names as an array    | `[]` (does not add image pull secrets to deployed pods)           |
+| `livenessProbe`                             | Specify livenessProbe for ProxySQL container | `{}`                                                                     |
+| `readinessProbe`                            | Specify readinessProbe for ProxySQL container | (see values.yaml)                                                       |
 | `nameOverride`                              | String to partially override proxysql.fullname template with a string (will prepend the release name) | `nil`            |
 | `fullnameOverride`                          | String to fully override proxysql.fullname template with a string                                     | `nil`            |
 | `service.type`                              | Kubernetes service type                             | `ClusterIP`                                                       |

--- a/dysnix/proxysql/README.md
+++ b/dysnix/proxysql/README.md
@@ -69,12 +69,15 @@ The following table lists the configurable parameters of the ProxySQL chart and 
 | `podDisruptionBudget.maxUnavailable`        | Maximum number / percentage of pods that may be made unavailable | 
 | `admin_variables.admin_credentials`         | ProxySQL admin credentials for the management (127.0.0.1:6032)  | `admin:admin`                                         |
 | `admin_variables.debug`                     | ProxySQL debug mode                                | `false`                                                            |
+| `admin_variables_include`                   | A list of files to @include in the `admin_variables` section | `[]`                                                     |
 | `mysql_variables.threads`                   | The number of background threads that ProxySQL uses in order to process MySQL traffic. | `4`                            |
 | `mysql_variables.max_connections`           | The maximum number of client connections that the proxy can handle. | `2048`                                            |
 | `mysql_variables.default_query_delay`       | Simple throttling mechanism for queries to the backends. Setting this variable to a non-zero value (in miliseconds) will delay the execution of all queries, globally.                                     | `0`                                                |
 | `mysql_variables.default_query_timeout`     | Mechanism for specifying the maximal duration of queries to the backend MySQL servers until ProxySQL should return an error to the MySQL client.                                                                 | `3600000` milliseconds                             |
 | `mysql_variables.monitor`                   | Enables or disables MySQL Monitor module.           | `false`                                                           |
+| `mysql_variables_include`                   | A list of files to @include in the `mysql_variables` section | `[]`                                                     |
 | `mysql_users`                               | Defines ProxySQL [users configuration](https://github.com/sysown/proxysql/wiki/Users-configuration)         | `[]`      |
+| `mysql_users_include`                       | A list of files to @include in the `mysql_users` section | `[]`                                                         |
 | `mysql_servers`                             | Defines ProxySQL [backend servers configuration](https://github.com/sysown/proxysql/wiki/MySQL-Server-Configuration) | `[]`  |
 | `mysql_query_rules`                         | Defines ProxySQL [Query Rules (routing)] (https://github.com/sysown/proxysql#configuring-proxysql-through-the-config-file) | `[]`  |
 | `ssl.auto`                                  | Automatically set `use_ssl` to `1` when the SSL configuration is provided | `true`  |

--- a/dysnix/proxysql/README.md
+++ b/dysnix/proxysql/README.md
@@ -88,6 +88,8 @@ The following table lists the configurable parameters of the ProxySQL chart and 
 | `ssl.cert`                                  | ProxySQL SSL certificate | `""`  |
 | `ssl.key`                                   | ProxySQL SSL key | `""`  |
 | `ssl.fromSecret`                            | Specify a secret containing `ca.pem`, `cert.pem` and `key.pem` SSL configuration | `""`  |
+| `volumes`                                   | Configure volumes for the ProxySQL pods | `[]`                                                                          |
+| `volumeMounts`                              | Configure volumeMounts for the ProxySQL container | `[]`                                                                |
 
 For more information please refer to the proxysql [config file](https://github.com/sysown/proxysql#configuring-proxysql-through-the-config-file) and [global variables](https://github.com/sysown/proxysql/wiki/Global-variables).
 

--- a/dysnix/proxysql/README.md
+++ b/dysnix/proxysql/README.md
@@ -82,6 +82,7 @@ The following table lists the configurable parameters of the ProxySQL chart and 
 | `mysql_users_include`                       | A list of files to @include in the `mysql_users` section | `[]`                                                         |
 | `mysql_servers`                             | Defines ProxySQL [backend servers configuration](https://github.com/sysown/proxysql/wiki/MySQL-Server-Configuration) | `[]`  |
 | `mysql_query_rules`                         | Defines ProxySQL [Query Rules (routing)] (https://github.com/sysown/proxysql#configuring-proxysql-through-the-config-file) | `[]`  |
+| `scheduler`                                 | Define ProxySQL [scheduler jobs](https://proxysql.com/documentation/scheduler/) | (see values.yaml)                      |
 | `ssl.auto`                                  | Automatically set `use_ssl` to `1` when the SSL configuration is provided | `true`  |
 | `ssl.ca`                                    | CA authority certificate to use | `""`  |
 | `ssl.cert`                                  | ProxySQL SSL certificate | `""`  |

--- a/dysnix/proxysql/files/proxysql.cnf
+++ b/dysnix/proxysql/files/proxysql.cnf
@@ -112,7 +112,7 @@ proxysql_servers=
 
 scheduler=
 (
-  {{- range $idx, $rule := .Values.schedulers }}
+  {{- range $idx, $rule := .Values.scheduler }}
   {
     rule_id={{ add $idx 1 }}
     {{- range $key, $value := $rule }}

--- a/dysnix/proxysql/files/proxysql.cnf
+++ b/dysnix/proxysql/files/proxysql.cnf
@@ -94,7 +94,7 @@ proxysql_servers=
   {{- $coreServiceName := printf "%s-core" (include "proxysql.fullname" .) }}
   {{- range $index, $_ := until $nodeCount }}
   {
-    hostname={{ printf "proxysql-core-%d.%s" $index $coreServiceName | toJson }}
+    hostname={{ printf "%s-%d.%s" $coreServiceName $index $coreServiceName | toJson }}
     port={{ $.Values.service.adminPort | toJson }}
     weight=100
   },

--- a/dysnix/proxysql/files/proxysql.cnf
+++ b/dysnix/proxysql/files/proxysql.cnf
@@ -2,7 +2,12 @@ datadir="/var/lib/proxysql"
 
 admin_variables=
 {
+  {{- range $include := .Values.admin_variables_include}}
+  @include "{{ $include }}"
+  {{- end }}
+  {{- if not .Values.admin_variables_include}}
   @include "/etc/proxysql/admin_credentials.cnf"
+  {{- end}}
   {{- if .Values.admin_variables.mysql_ifaces }}
   interfaces={{ .Values.admin_variables.mysql_ifaces | quote }}
   {{- else }}
@@ -15,6 +20,9 @@ admin_variables=
 
 mysql_variables=
 {
+  {{- range $include := .Values.mysql_variables_include}}
+  @include "{{ $include }}"
+  {{- end }}
   {{/* ProxySQL SSL config */}}
   {{- if .Values.ssl.fromSecret }}
   ssl_p2s_ca="{{ include "proxysql.sslDir" . }}/{{ .Values.ssl.ca_file }}"
@@ -52,6 +60,9 @@ mysql_servers =
 
 mysql_users:
 (
+  {{- range $include := .Values.mysql_users_include}}
+  @include "{{ $include }}"
+  {{- end }}
   {{- range $_, $user := .Values.mysql_users }}
   {
     {{- if hasKey $user "active" -}}

--- a/dysnix/proxysql/templates/daemonset.yaml
+++ b/dysnix/proxysql/templates/daemonset.yaml
@@ -73,15 +73,11 @@ spec:
             - name: web
               containerPort: {{ .Values.service.webPort }}
               protocol: TCP
-          {{- if .Values.readinessProbe.enabled }}
-          readinessProbe:
-            exec:
-              command: ["bash", "-c", "true <>/dev/tcp/127.0.0.1/{{ .Values.service.proxyPort }}"]
-            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.readinessProbe.successThreshold }}
-            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          {{- with .Values.livenessProbe }}
+          livenessProbe: {{ toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe: {{ toYaml . | nindent 12 }}
           {{- end }}
           resources:
             {{- toYaml (default .Values.resources .Values.proxysql_cluster.satellite.daemonset.resources) | nindent 12 }}

--- a/dysnix/proxysql/templates/daemonset.yaml
+++ b/dysnix/proxysql/templates/daemonset.yaml
@@ -82,6 +82,9 @@ spec:
           resources:
             {{- toYaml (default .Values.resources .Values.proxysql_cluster.satellite.daemonset.resources) | nindent 12 }}
           volumeMounts:
+            {{- with .Values.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
             - name: data
               mountPath: /data/proxysql
             - name: conf
@@ -156,6 +159,9 @@ spec:
     {{- end }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds | int }}
       volumes:
+        {{- with .Values.volumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         - name: data
           emptyDir: {}
         - name: secrets

--- a/dysnix/proxysql/templates/deployment.yaml
+++ b/dysnix/proxysql/templates/deployment.yaml
@@ -83,6 +83,9 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
+            {{- with .Values.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
             - name: data
               mountPath: /data/proxysql
             - name: conf
@@ -157,6 +160,9 @@ spec:
     {{- end }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds | int }}
       volumes:
+        {{- with .Values.volumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         - name: data
           emptyDir: {}
         - name: secrets

--- a/dysnix/proxysql/templates/deployment.yaml
+++ b/dysnix/proxysql/templates/deployment.yaml
@@ -74,15 +74,11 @@ spec:
             - name: web
               containerPort: {{ .Values.service.webPort }}
               protocol: TCP
-          {{- if .Values.readinessProbe.enabled }}
-          readinessProbe:
-            exec:
-              command: ["bash", "-c", "true <>/dev/tcp/127.0.0.1/{{ .Values.service.proxyPort }}"]
-            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.readinessProbe.successThreshold }}
-            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          {{- with .Values.livenessProbe }}
+          livenessProbe: {{ toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe: {{ toYaml . | nindent 12 }}
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/dysnix/proxysql/templates/service.yaml
+++ b/dysnix/proxysql/templates/service.yaml
@@ -70,6 +70,14 @@ metadata:
     {{- end }}
 spec:
   ports:
+    {{- if .Values.proxysql_cluster.core.service.exposeProxyPort }}
+    - name: proxy
+      port: {{ .Values.service.proxyPort }}
+      targetPort: proxy
+      {{- if .Values.service.proxyNodePort }}
+      nodePort: {{ .Values.service.proxyNodePort }}
+      {{- end }}
+    {{- end }}
     - name: admin
       port: {{ .Values.service.adminPort }}
       targetPort: admin

--- a/dysnix/proxysql/templates/statefulset.yaml
+++ b/dysnix/proxysql/templates/statefulset.yaml
@@ -88,6 +88,9 @@ spec:
           resources:
             {{- toYaml (default .Values.resources .Values.proxysql_cluster.core.statefullset.resources) | nindent 12 }}
           volumeMounts:
+            {{- with .Values.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
             - name: data
               mountPath: /data/proxysql
             - name: conf
@@ -162,6 +165,9 @@ spec:
     {{- end }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds | int }}
       volumes:
+        {{- with .Values.volumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         - name: data
           emptyDir: {}
         - name: secrets

--- a/dysnix/proxysql/templates/statefulset.yaml
+++ b/dysnix/proxysql/templates/statefulset.yaml
@@ -75,15 +75,11 @@ spec:
             - name: web
               containerPort: {{ .Values.service.webPort }}
               protocol: TCP
-          {{- if .Values.readinessProbe.enabled }}
-          readinessProbe:
-            exec:
-              command: ["bash", "-c", "true <>/dev/tcp/127.0.0.1/{{ .Values.service.proxyPort }}"]
-            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.readinessProbe.successThreshold }}
-            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          {{- with .Values.livenessProbe }}
+          livenessProbe: {{ toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe: {{ toYaml . | nindent 12 }}
           {{- end }}
           resources:
             {{- toYaml (default .Values.resources .Values.proxysql_cluster.core.statefullset.resources) | nindent 12 }}

--- a/dysnix/proxysql/tests/configmap-include-directives_test.yaml
+++ b/dysnix/proxysql/tests/configmap-include-directives_test.yaml
@@ -10,12 +10,12 @@ tests:
 
     asserts:
       - matchRegex:
-          path: .data["proxysql.cnf"]
+          path: data.[proxysql.cnf]
           pattern: '@include "/etc/proxysql/secrets/admin_vars\.cnf"'
 
       # our includes should replace the insecure creds include
       - notMatchRegex:
-          path: .data["proxysql.cnf"]
+          path: data.[proxysql.cnf]
           pattern: '@include "/etc/proxysql/admin_credentials\.cnf"'
 
   - it: mysql_variables include
@@ -25,7 +25,7 @@ tests:
 
     asserts:
       - matchRegex:
-          path: .data["proxysql.cnf"]
+          path: data.[proxysql.cnf]
           pattern: '@include "/etc/proxysql/secrets/mysql_vars\.cnf"'
 
   - it: mysql_users include
@@ -35,5 +35,5 @@ tests:
 
     asserts:
       - matchRegex:
-          path: .data["proxysql.cnf"]
+          path: data.[proxysql.cnf]
           pattern: '@include "/etc/proxysql/secrets/mysql_users\.cnf"'

--- a/dysnix/proxysql/tests/configmap-include-directives_test.yaml
+++ b/dysnix/proxysql/tests/configmap-include-directives_test.yaml
@@ -1,0 +1,39 @@
+suite: configmap
+templates:
+  - configmap.yaml
+
+tests:
+  - it: admin_variables include
+    values:
+      - ./values/common.yaml
+      - ./values/admin-variables-include.yaml
+
+    asserts:
+      - matchRegex:
+          path: .data["proxysql.cnf"]
+          pattern: '@include "/etc/proxysql/secrets/admin_vars\.cnf"'
+
+      # our includes should replace the insecure creds include
+      - notMatchRegex:
+          path: .data["proxysql.cnf"]
+          pattern: '@include "/etc/proxysql/admin_credentials\.cnf"'
+
+  - it: mysql_variables include
+    values:
+      - ./values/common.yaml
+      - ./values/mysql-variables-include.yaml
+
+    asserts:
+      - matchRegex:
+          path: .data["proxysql.cnf"]
+          pattern: '@include "/etc/proxysql/secrets/mysql_vars\.cnf"'
+
+  - it: mysql_users include
+    values:
+      - ./values/common.yaml
+      - ./values/mysql-users-include.yaml
+
+    asserts:
+      - matchRegex:
+          path: .data["proxysql.cnf"]
+          pattern: '@include "/etc/proxysql/secrets/mysql_users\.cnf"'

--- a/dysnix/proxysql/tests/configmap-proxysql-servers_test.yaml
+++ b/dysnix/proxysql/tests/configmap-proxysql-servers_test.yaml
@@ -1,0 +1,18 @@
+suite: configmap
+templates:
+  - configmap.yaml
+
+tests:
+  - it: proxysql_servers correct
+    values:
+      - ./values/common.yaml
+      - ./values/proxysql-servers.yaml
+
+    asserts:
+      - matchRegex:
+          path: data.[proxysql.cnf]
+          # NOTE: the renderer organizes the keys in alphabetical order
+          pattern: |
+            \s+hostname="foobar-test-core-0.foobar-test-core"
+            \s+port=6032
+            \s+weight=100

--- a/dysnix/proxysql/tests/configmap-scheduler_test.yaml
+++ b/dysnix/proxysql/tests/configmap-scheduler_test.yaml
@@ -1,0 +1,19 @@
+suite: configmap
+templates:
+  - configmap.yaml
+
+tests:
+  - it: scheduler correct
+    values:
+      - ./values/common.yaml
+      - ./values/scheduler.yaml
+
+    asserts:
+      - matchRegex:
+          path: .data["proxysql.cnf"]
+          # NOTE: the renderer organizes the keys in alphabetical order
+          pattern: |
+            \s+active=1
+            \s+comment="job to cleanup stats_mysql_query_digest table"
+            \s+filename="/usr/local/bin/cleanup-digest.bash"
+            \s+interval_ms=300000

--- a/dysnix/proxysql/tests/configmap-scheduler_test.yaml
+++ b/dysnix/proxysql/tests/configmap-scheduler_test.yaml
@@ -10,7 +10,7 @@ tests:
 
     asserts:
       - matchRegex:
-          path: .data["proxysql.cnf"]
+          path: data.[proxysql.cnf]
           # NOTE: the renderer organizes the keys in alphabetical order
           pattern: |
             \s+active=1

--- a/dysnix/proxysql/tests/daemonset-liveness-readiness-probes_test.yaml
+++ b/dysnix/proxysql/tests/daemonset-liveness-readiness-probes_test.yaml
@@ -1,0 +1,48 @@
+suite: daemonset
+templates:
+  - configmap-scripts.yaml
+  - configmap.yaml
+  - secret.yaml
+  - daemonset.yaml
+
+tests:
+  - it: readinessProbe correct
+    values:
+      - ./values/common.yaml
+      - ./values/readinessprobe.yaml
+    set: &sets
+      proxysql_cluster.satellite.enabled: true
+      proxysql_cluster.satellite.kind: DaemonSet
+
+    asserts:
+      - template: daemonset.yaml
+        equal:
+          path: spec.template.spec.containers[0].readinessProbe
+          value:
+            exec:
+              command:
+                - "bash"
+                - "-c"
+                - "true <>/dev/tcp/127.0.0.1/{{ .Values.service.proxyPort }}"
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+
+  - it: livenessProbe correct
+    values:
+      - ./values/common.yaml
+      - ./values/livenessprobe.yaml
+    set: *sets
+
+    asserts:
+      - template: daemonset.yaml
+        equal:
+          path: spec.template.spec.containers[0].livenessProbe
+          value:
+            exec:
+              command:
+                - sh
+                - "-c"
+                - uptime

--- a/dysnix/proxysql/tests/daemonset-volumes-and-volumemounts_test.yaml
+++ b/dysnix/proxysql/tests/daemonset-volumes-and-volumemounts_test.yaml
@@ -1,0 +1,39 @@
+suite: deployment
+templates:
+  - configmap-scripts.yaml
+  - configmap.yaml
+  - secret.yaml
+  - daemonset.yaml
+
+tests:
+  - it: pod volumes correct
+    values:
+      - ./values/common.yaml
+      - ./values/volumes.yaml
+    set: &sets
+      proxysql_cluster.satellite.enabled: true
+      proxysql_cluster.satellite.kind: DaemonSet
+
+    asserts:
+      - template: daemonset.yaml
+        contains:
+          path: spec.template.spec.volumes
+          content:
+            name: admin-vars
+            secret:
+              secretName: admin-vars
+
+  - it: proxysql container volumeMounts correct
+    values:
+      - ./values/common.yaml
+      - ./values/volumeMounts.yaml
+    set: *sets
+
+    asserts:
+      - template: daemonset.yaml
+        contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: admin-vars
+            mountPath: /etc/proxysql/admin_vars.cnf
+            subPath: admin_vars.cnf

--- a/dysnix/proxysql/tests/daemonset-volumes-and-volumemounts_test.yaml
+++ b/dysnix/proxysql/tests/daemonset-volumes-and-volumemounts_test.yaml
@@ -26,7 +26,7 @@ tests:
   - it: proxysql container volumeMounts correct
     values:
       - ./values/common.yaml
-      - ./values/volumeMounts.yaml
+      - ./values/volumemounts.yaml
     set: *sets
 
     asserts:

--- a/dysnix/proxysql/tests/deployment-liveness-readiness-probes_test.yaml
+++ b/dysnix/proxysql/tests/deployment-liveness-readiness-probes_test.yaml
@@ -1,0 +1,48 @@
+suite: deployment
+templates:
+  - configmap-scripts.yaml
+  - configmap.yaml
+  - secret.yaml
+  - deployment.yaml
+
+tests:
+  - it: readinessProbe correct
+    values:
+      - ./values/common.yaml
+      - ./values/readinessprobe.yaml
+    set: &sets
+      proxysql_cluster.satellite.enabled: true
+      proxysql_cluster.satellite.kind: Deployment
+
+    asserts:
+      - template: deployment.yaml
+        equal:
+          path: spec.template.spec.containers[0].readinessProbe
+          value:
+            exec:
+              command:
+                - "bash"
+                - "-c"
+                - "true <>/dev/tcp/127.0.0.1/{{ .Values.service.proxyPort }}"
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+
+  - it: livenessProbe correct
+    values:
+      - ./values/common.yaml
+      - ./values/livenessprobe.yaml
+    set: *sets
+
+    asserts:
+      - template: deployment.yaml
+        equal:
+          path: spec.template.spec.containers[0].livenessProbe
+          value:
+            exec:
+              command:
+                - sh
+                - "-c"
+                - uptime

--- a/dysnix/proxysql/tests/deployment-volumes-and-volumemounts_test.yaml
+++ b/dysnix/proxysql/tests/deployment-volumes-and-volumemounts_test.yaml
@@ -1,0 +1,39 @@
+suite: deployment
+templates:
+  - configmap-scripts.yaml
+  - configmap.yaml
+  - secret.yaml
+  - deployment.yaml
+
+tests:
+  - it: pod volumes correct
+    values:
+      - ./values/common.yaml
+      - ./values/volumes.yaml
+    set: &sets
+      proxysql_cluster.satellite.enabled: true
+      proxysql_cluster.satellite.kind: Deployment
+
+    asserts:
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.volumes
+          content:
+            name: admin-vars
+            secret:
+              secretName: admin-vars
+
+  - it: proxysql container volumeMounts correct
+    values:
+      - ./values/common.yaml
+      - ./values/volumeMounts.yaml
+    set: *sets
+
+    asserts:
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: admin-vars
+            mountPath: /etc/proxysql/admin_vars.cnf
+            subPath: admin_vars.cnf

--- a/dysnix/proxysql/tests/deployment-volumes-and-volumemounts_test.yaml
+++ b/dysnix/proxysql/tests/deployment-volumes-and-volumemounts_test.yaml
@@ -26,7 +26,7 @@ tests:
   - it: proxysql container volumeMounts correct
     values:
       - ./values/common.yaml
-      - ./values/volumeMounts.yaml
+      - ./values/volumemounts.yaml
     set: *sets
 
     asserts:

--- a/dysnix/proxysql/tests/service-core-expose-proxy-port_test.yaml
+++ b/dysnix/proxysql/tests/service-core-expose-proxy-port_test.yaml
@@ -1,0 +1,37 @@
+suite: service
+templates:
+  - service.yaml
+
+tests:
+  - it: core service default no proxy port
+    documentIndex: 1
+    values:
+      - ./values/common.yaml
+    set:
+      proxysql_cluster.enabled: true
+      proxysql_cluster.core.enabled: true
+
+    asserts:
+      - notContains:
+          path: spec.ports
+          content:
+            name: proxy
+            port: 6033
+            targetPort: proxy
+
+  - it: core service expose proxy port correct
+    documentIndex: 1
+    values:
+      - ./values/common.yaml
+    set:
+      proxysql_cluster.enabled: true
+      proxysql_cluster.core.enabled: true
+      proxysql_cluster.core.service.exposeProxyPort: true
+
+    asserts:
+      - contains:
+          path: spec.ports
+          content:
+            name: proxy
+            port: 6033
+            targetPort: proxy

--- a/dysnix/proxysql/tests/statefulset-liveness-readiness-probes_test.yaml
+++ b/dysnix/proxysql/tests/statefulset-liveness-readiness-probes_test.yaml
@@ -1,0 +1,48 @@
+suite: statefulset
+templates:
+  - configmap-scripts.yaml
+  - configmap.yaml
+  - secret.yaml
+  - statefulset.yaml
+
+tests:
+  - it: readinessProbe correct
+    values:
+      - ./values/common.yaml
+      - ./values/readinessprobe.yaml
+    set: &sets
+      proxysql_cluster.satellite.enabled: false
+      proxysql_cluster.enabled: true
+
+    asserts:
+      - template: statefulset.yaml
+        equal:
+          path: spec.template.spec.containers[0].readinessProbe
+          value:
+            exec:
+              command:
+                - "bash"
+                - "-c"
+                - "true <>/dev/tcp/127.0.0.1/{{ .Values.service.proxyPort }}"
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+
+  - it: livenessProbe correct
+    values:
+      - ./values/common.yaml
+      - ./values/livenessprobe.yaml
+    set: *sets
+
+    asserts:
+      - template: statefulset.yaml
+        equal:
+          path: spec.template.spec.containers[0].livenessProbe
+          value:
+            exec:
+              command:
+                - sh
+                - "-c"
+                - uptime

--- a/dysnix/proxysql/tests/statefulset-volumes-and-volumemounts_test.yaml
+++ b/dysnix/proxysql/tests/statefulset-volumes-and-volumemounts_test.yaml
@@ -1,0 +1,39 @@
+suite: statefulset
+templates:
+  - configmap-scripts.yaml
+  - configmap.yaml
+  - secret.yaml
+  - statefulset.yaml
+
+tests:
+  - it: pod volumes correct
+    values:
+      - ./values/common.yaml
+      - ./values/volumes.yaml
+    set: &sets
+      proxysql_cluster.satellite.enabled: false
+      proxysql_cluster.enabled: true
+
+    asserts:
+      - template: statefulset.yaml
+        contains:
+          path: spec.template.spec.volumes
+          content:
+            name: admin-vars
+            secret:
+              secretName: admin-vars
+
+  - it: proxysql container volumeMounts correct
+    values:
+      - ./values/common.yaml
+      - ./values/volumeMounts.yaml
+    set: *sets
+
+    asserts:
+      - template: statefulset.yaml
+        contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: admin-vars
+            mountPath: /etc/proxysql/admin_vars.cnf
+            subPath: admin_vars.cnf

--- a/dysnix/proxysql/tests/statefulset-volumes-and-volumemounts_test.yaml
+++ b/dysnix/proxysql/tests/statefulset-volumes-and-volumemounts_test.yaml
@@ -26,7 +26,7 @@ tests:
   - it: proxysql container volumeMounts correct
     values:
       - ./values/common.yaml
-      - ./values/volumeMounts.yaml
+      - ./values/volumemounts.yaml
     set: *sets
 
     asserts:

--- a/dysnix/proxysql/tests/values/admin-variables-include.yaml
+++ b/dysnix/proxysql/tests/values/admin-variables-include.yaml
@@ -1,0 +1,2 @@
+admin_variables_include:
+  - /etc/proxysql/secrets/admin_vars.cnf

--- a/dysnix/proxysql/tests/values/common.yaml
+++ b/dysnix/proxysql/tests/values/common.yaml
@@ -49,13 +49,14 @@ podLabels: {}
 podDisruptionBudget:
   enabled: false
   minAvailable: 1
+
 readinessProbe:
-  enabled: true
   initialDelaySeconds: 5
   periodSeconds: 10
   timeoutSeconds: 1
   successThreshold: 1
   failureThreshold: 3
+
 ssl:
   auto: true
   ca: ""

--- a/dysnix/proxysql/tests/values/common.yaml
+++ b/dysnix/proxysql/tests/values/common.yaml
@@ -75,6 +75,8 @@ secret:
 admin_variables:
   debug: false
 
+admin_variables_include: []
+
 mysql_variables:
   threads: 4
 
@@ -84,7 +86,11 @@ mysql_variables:
   default_query_timeout: 3600000
   monitor_enabled: false
 
+mysql_variables_include: []
+
 mysql_users:
+
+mysql_users_include: []
 
 mysql_servers:
 

--- a/dysnix/proxysql/tests/values/common.yaml
+++ b/dysnix/proxysql/tests/values/common.yaml
@@ -1,0 +1,185 @@
+replicas: 1
+
+image:
+  registry: docker.io
+  repository: proxysql/proxysql
+  tag: "2.4.4"
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: true
+  name:
+
+podSecurityContext:
+  runAsNonRoot: true
+  fsGroup: 999
+  runAsUser: 999
+  runAsGroup: 999
+
+securityContext: {}
+service:
+  type: ClusterIP
+
+  proxyPort: 6033
+
+  adminPort: 6032
+
+  webPort: 6080
+  annotations: {}
+
+resources: {}
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+commonAnnotations: {}
+
+commonLabels: {}
+
+podAnnotations: {}
+
+podLabels: {}
+podDisruptionBudget:
+  enabled: false
+  minAvailable: 1
+readinessProbe:
+  enabled: true
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 1
+  successThreshold: 1
+  failureThreshold: 3
+ssl:
+  auto: true
+  ca: ""
+  cert: ""
+  key: ""
+
+  sslDir: "/etc/proxysql"
+  ca_file: "ca.pem"
+  cert_file: "cert.pem"
+  key_file: "key.pem"
+  fromSecret: ""
+
+secret:
+  admin_user: "proxysql-admin"
+  admin_password: "proxysql"
+
+admin_variables:
+  debug: false
+
+mysql_variables:
+  threads: 4
+
+  max_connections: 2048
+  default_query_delay: 0
+
+  default_query_timeout: 3600000
+  monitor_enabled: false
+
+mysql_users:
+
+mysql_servers:
+
+mysql_query_rules:
+
+use_default_proxysql_servers: true
+additional_proxysql_servers:
+
+proxysql_cluster:
+  enabled: false
+
+  secret:
+    cluster_username: "proxysql-cluster"
+    cluster_password: "proxysql"
+
+  core:
+    enabled: true
+
+    replicas: 3
+    exit_on_error: false
+
+    statefullset:
+      nodeSelector: {}
+      tolerations: []
+      affinity: {}
+      podAnnotations: {}
+
+      resources: {}
+
+    service:
+      name:
+
+  satellite:
+    kind: "DaemonSet"
+
+    enabled: true
+    replicas: 3
+    exit_on_error: false
+
+    daemonset:
+      nodeSelector: {}
+      tolerations: []
+      affinity: {}
+
+      podAnnotations: {}
+
+      resources: {}
+
+    service:
+      name:
+  job:
+    image:
+      registry: docker.io
+      repository: mysql
+      tag: "8"
+      pullPolicy: IfNotPresent
+
+    enabled: true
+    backoffLimit: 3
+    ttlSecondsAfterFinished: 3600
+
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}
+    podAnnotations: {}
+
+    resources: {}
+
+  healthcheck:
+    sidecar:
+      enabled: false
+      image: mysql:debian
+      command:
+        - /usr/local/bin/proxysql_cluster_healthcheck.sh
+      config:
+        psql_user: monitor
+        psql_pass: monitor
+        psql_host: 127.0.0.1
+        psql_host_port: 6032
+
+        diff_check_limit: 10
+        kill_if_healthcheck_failed: true
+      securityContext:
+        runAsUser: 999
+        runAsGroup: 999
+
+debug:
+  sidecar:
+    enabled: false
+    image: mysql:debian
+    command:
+      - /bin/sleep
+      - infinity
+    securityContext:
+      runAsUser: 999
+      runAsGroup: 999
+
+terminationGracePeriodSeconds: 60

--- a/dysnix/proxysql/tests/values/common.yaml
+++ b/dysnix/proxysql/tests/values/common.yaml
@@ -123,6 +123,7 @@ proxysql_cluster:
 
     service:
       name:
+      exposeProxyPort: false
 
   satellite:
     kind: "DaemonSet"

--- a/dysnix/proxysql/tests/values/livenessprobe.yaml
+++ b/dysnix/proxysql/tests/values/livenessprobe.yaml
@@ -1,0 +1,6 @@
+livenessProbe:
+  exec:
+    command:
+      - sh
+      - "-c"
+      - uptime

--- a/dysnix/proxysql/tests/values/mysql-users-include.yaml
+++ b/dysnix/proxysql/tests/values/mysql-users-include.yaml
@@ -1,0 +1,2 @@
+mysql_users_include:
+  - /etc/proxysql/secrets/mysql_users.cnf

--- a/dysnix/proxysql/tests/values/mysql-variables-include.yaml
+++ b/dysnix/proxysql/tests/values/mysql-variables-include.yaml
@@ -1,0 +1,2 @@
+mysql_variables_include:
+  - /etc/proxysql/secrets/mysql_vars.cnf

--- a/dysnix/proxysql/tests/values/proxysql-servers.yaml
+++ b/dysnix/proxysql/tests/values/proxysql-servers.yaml
@@ -1,0 +1,1 @@
+fullnameOverride: foobar-test

--- a/dysnix/proxysql/tests/values/readinessprobe.yaml
+++ b/dysnix/proxysql/tests/values/readinessprobe.yaml
@@ -1,0 +1,11 @@
+readinessProbe:
+  exec:
+    command:
+      - "bash"
+      - "-c"
+      - "true <>/dev/tcp/127.0.0.1/{{ .Values.service.proxyPort }}"
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 1
+  successThreshold: 1
+  failureThreshold: 3

--- a/dysnix/proxysql/tests/values/scheduler.yaml
+++ b/dysnix/proxysql/tests/values/scheduler.yaml
@@ -1,0 +1,5 @@
+scheduler:
+  - active: 1
+    interval_ms: 300000
+    filename: "/usr/local/bin/cleanup-digest.bash"
+    comment: "job to cleanup stats_mysql_query_digest table"

--- a/dysnix/proxysql/tests/values/volumemounts.yaml
+++ b/dysnix/proxysql/tests/values/volumemounts.yaml
@@ -1,0 +1,4 @@
+volumeMounts:
+  - name: admin-vars
+    mountPath: /etc/proxysql/admin_vars.cnf
+    subPath: admin_vars.cnf

--- a/dysnix/proxysql/tests/values/volumes.yaml
+++ b/dysnix/proxysql/tests/values/volumes.yaml
@@ -1,0 +1,4 @@
+volumes:
+  - name: admin-vars
+    secret:
+      secretName: admin-vars

--- a/dysnix/proxysql/values.yaml
+++ b/dysnix/proxysql/values.yaml
@@ -21,13 +21,24 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name:
 
+# volumes:
+#   - name: admin-vars
+#     secret:
+#       secretName: admin-vars
+
+# volumeMounts:
+#   - name: secrets
+#     mountPath: /etc/proxysql/admin_vars.cnf
+#     subPath: admin_vars.cnf
+
 podSecurityContext:
   runAsNonRoot: true
   fsGroup: 999
   runAsUser: 999
   runAsGroup: 999
 
-securityContext: {}
+securityContext:
+  {}
   # capabilities:
   #   drop:
   #   - ALL
@@ -81,7 +92,8 @@ service:
 
 # Default pod resource allocation.
 # Will be applied if not specified otherwise.
-resources: {}
+resources:
+  {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -150,10 +162,10 @@ ssl:
   cert: ""
   key: ""
 
-  sslDir: "/etc/proxysql"   # ProxySQL SSL directory
-  ca_file: "ca.pem"         # Name of the CA file
-  cert_file: "cert.pem"     # Name of the Cert file
-  key_file: "key.pem"       # Name of the private Key file
+  sslDir: "/etc/proxysql" # ProxySQL SSL directory
+  ca_file: "ca.pem" # Name of the CA file
+  cert_file: "cert.pem" # Name of the Cert file
+  key_file: "key.pem" # Name of the private Key file
 
   ## Loads ca.pem, cert.pem, and key.pem from an existingSecret
   fromSecret: ""
@@ -230,7 +242,6 @@ mysql_query_rules:
   #   match_pattern: "^SELECT .* FOR UPDATE$"
   #   destination_hostgroup: 0
   #   apply: 1
-
 
 ## If enabled, generate automagically a list of proxysql servers based on the
 #    the number statefullset 'proxysql-core' replicas (default 3).
@@ -332,7 +343,6 @@ proxysql_cluster:
   #   starts at version/checksum = 0. As per specification the satellites won't sync the changes
   #   until the version/checksum is not 0.
   job:
-
     image:
       registry: docker.io
       repository: mysql
@@ -370,11 +380,11 @@ proxysql_cluster:
       config:
         psql_user: monitor
         psql_pass: monitor
-        psql_host: 127.0.0.1  # The listening core host/pod
-        psql_host_port: 6032  # The admin port
+        psql_host: 127.0.0.1 # The listening core host/pod
+        psql_host_port: 6032 # The admin port
 
-        diff_check_limit: 10  # How many diff_check errors are tolerated before the healthcheck fails
-        kill_if_healthcheck_failed: true  # Kill proxysql daemon if the healthcheck fails the test
+        diff_check_limit: 10 # How many diff_check errors are tolerated before the healthcheck fails
+        kill_if_healthcheck_failed: true # Kill proxysql daemon if the healthcheck fails the test
       securityContext:
         runAsUser: 999
         runAsGroup: 999

--- a/dysnix/proxysql/values.yaml
+++ b/dysnix/proxysql/values.yaml
@@ -177,10 +177,10 @@ ssl:
   cert: ""
   key: ""
 
-  sslDir: "/etc/proxysql" # ProxySQL SSL directory
-  ca_file: "ca.pem" # Name of the CA file
-  cert_file: "cert.pem" # Name of the Cert file
-  key_file: "key.pem" # Name of the private Key file
+  sslDir: "/etc/proxysql"  # ProxySQL SSL directory
+  ca_file: "ca.pem"  # Name of the CA file
+  cert_file: "cert.pem"  # Name of the Cert file
+  key_file: "key.pem"  # Name of the private Key file
 
   ## Loads ca.pem, cert.pem, and key.pem from an existingSecret
   fromSecret: ""
@@ -417,11 +417,11 @@ proxysql_cluster:
       config:
         psql_user: monitor
         psql_pass: monitor
-        psql_host: 127.0.0.1 # The listening core host/pod
-        psql_host_port: 6032 # The admin port
+        psql_host: 127.0.0.1  # The listening core host/pod
+        psql_host_port: 6032  # The admin port
 
-        diff_check_limit: 10 # How many diff_check errors are tolerated before the healthcheck fails
-        kill_if_healthcheck_failed: true # Kill proxysql daemon if the healthcheck fails the test
+        diff_check_limit: 10  # How many diff_check errors are tolerated before the healthcheck fails
+        kill_if_healthcheck_failed: true  # Kill proxysql daemon if the healthcheck fails the test
       securityContext:
         runAsUser: 999
         runAsGroup: 999

--- a/dysnix/proxysql/values.yaml
+++ b/dysnix/proxysql/values.yaml
@@ -142,7 +142,11 @@ podDisruptionBudget:
   # maxUnavailable: 1
 
 readinessProbe:
-  enabled: true
+  exec:
+    command:
+      - "bash"
+      - "-c"
+      - "true <>/dev/tcp/127.0.0.1/{{ .Values.service.proxyPort }}"
   initialDelaySeconds: 5
   ##
   ## Default Kubernetes values
@@ -150,6 +154,14 @@ readinessProbe:
   timeoutSeconds: 1
   successThreshold: 1
   failureThreshold: 3
+
+livenessProbe:
+  {}
+  # exec:
+  #   command:
+  #     - sh
+  #     - "-c"
+  #     - uptime
 
 # Enable SSL communication with the backend MySQL servers
 ssl:

--- a/dysnix/proxysql/values.yaml
+++ b/dysnix/proxysql/values.yaml
@@ -21,15 +21,18 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name:
 
-# volumes:
-#   - name: admin-vars
+## Configure volumes for the ProxySQL pods
+##
+volumes: []
+#   - name: secret-confs
 #     secret:
-#       secretName: admin-vars
+#       secretName: secret-confs
 
-# volumeMounts:
-#   - name: secrets
-#     mountPath: /etc/proxysql/admin_vars.cnf
-#     subPath: admin_vars.cnf
+## Configure volumeMounts for the ProxySQL container
+##
+volumeMounts: []
+#   - name: secret-confs
+#     mountPath: /etc/proxysql/secrets
 
 podSecurityContext:
   runAsNonRoot: true

--- a/dysnix/proxysql/values.yaml
+++ b/dysnix/proxysql/values.yaml
@@ -270,6 +270,13 @@ mysql_query_rules:
   #   destination_hostgroup: 0
   #   apply: 1
 
+scheduler:
+  []
+  # - active: 1
+  #   interval_ms: 300000
+  #   filename: "/usr/local/bin/cleanup-digest.bash"
+  #   comment: "job to cleanup stats_mysql_query_digest table"
+
 ## If enabled, generate automagically a list of proxysql servers based on the
 #    the number statefullset 'proxysql-core' replicas (default 3).
 use_default_proxysql_servers: true

--- a/dysnix/proxysql/values.yaml
+++ b/dysnix/proxysql/values.yaml
@@ -188,6 +188,11 @@ admin_variables:
 
   # refresh_interval: 2000
 
+## A list of files to @include in the `admin_variables` section
+##
+admin_variables_include: []
+#   - /etc/proxysql/secrets/admin_vars.cnf
+
 mysql_variables:
   ## ref: https://github.com/sysown/proxysql/wiki/Global-variables
   #
@@ -212,6 +217,11 @@ mysql_variables:
   # monitor_password: "monitor"
   # monitor_history: 600000
 
+## A list of files to @include in the `mysql_variables` section
+##
+mysql_variables_include: []
+#   - /etc/proxysql/secrets/mysql_vars.cnf
+
 ## Configures ProxySQL mysql users.
 #  For MySQL 8.0 paswords must be mysql_native_password.
 #  ref: https://github.com/sysown/proxysql/wiki/MySQL-8.0
@@ -223,6 +233,11 @@ mysql_users:
   #   max_connections: 200
   #   default_schema: "information_schema"
   #   active: 1
+
+## A list of files to @include in the `mysql_users` section
+##
+mysql_users_include: []
+#   - /etc/proxysql/secrets/mysql_users.cnf
 
 ## Define MySQL backend servers
 #

--- a/dysnix/proxysql/values.yaml
+++ b/dysnix/proxysql/values.yaml
@@ -331,6 +331,8 @@ proxysql_cluster:
     service:
       # Override default core service name
       name:
+      # Expose the proxy (to MySQL servers) port
+      exposeProxyPort: false
 
   satellite:
     # Select the Kubernetes Resource type for the Satellite nodes,


### PR DESCRIPTION
The pod hostnames were hardcoded which only works if the release name matches the hardcoding.