### PR TITLE
[bsc] improve CLI args

### DIFF
--- a/dysnix/bsc/Chart.yaml
+++ b/dysnix/bsc/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: bsc
 description: Binance Smart Chain chart for Kubernetes
-version: "0.6.33"
-appVersion: "1.2.15"
+version: 0.6.33
+appVersion: 1.2.15
 
 keywords:
   - geth

--- a/dysnix/bsc/Chart.yaml
+++ b/dysnix/bsc/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: bsc
 description: Binance Smart Chain chart for Kubernetes
-version: "0.6.32"
-appVersion: "v1.2.4"
+version: "0.6.33"
+appVersion: "1.2.15"
 
 keywords:
   - geth

--- a/dysnix/bsc/templates/configs/_config.txt
+++ b/dysnix/bsc/templates/configs/_config.txt
@@ -1,44 +1,36 @@
 [Eth]
 NetworkId = 56
+LightPeers = 100
 NoPruning = false
 NoPrefetch = false
-LightPeers = 100
-UltraLightFraction = 75
-TrieTimeout = 100000000000
-EnablePreimageRecording = false
-EWASMInterpreter = ""
-EVMInterpreter = ""
+TrieTimeout = 150000000000
 DisablePeerTxBroadcast = true
 
 [Eth.Miner]
-GasFloor = 30000000
-GasCeil = 40000000
-GasPrice = 1000000000
+GasCeil = 140000000
+GasPrice = 3000000000
 Recommit = 10000000000
-Noverify = false
 
 [Eth.TxPool]
 Locals = []
 NoLocals = true
 Journal = "transactions.rlp"
 Rejournal = 3600000000000
-PriceLimit = 1000000000
+PriceLimit = 3000000000
 PriceBump = 10
-AccountSlots = 512
-GlobalSlots = 10000
-AccountQueue = 256
-GlobalQueue = 5000
-Lifetime = 10800000000000
+AccountSlots = 200
+GlobalSlots = 8000
+AccountQueue = 200
+GlobalQueue = 4000
 
 [Eth.GPO]
 Blocks = 20
 Percentile = 60
-OracleThreshold = 20
+OracleThreshold = 1000
 
 [Node]
 IPCPath = "geth.ipc"
 HTTPHost = "0.0.0.0"
-NoUSB = true
 InsecureUnlockAllowed = false
 HTTPPort = {{ .Values.service.rpcPort }}
 HTTPVirtualHosts = ["{{ join "\",\"" .Values.bsc.rpcVhosts }}"]

--- a/dysnix/bsc/templates/statefulset.yaml
+++ b/dysnix/bsc/templates/statefulset.yaml
@@ -84,7 +84,7 @@ spec:
           - --syncmode={{ .Values.bsc.syncmode }}
           - --gcmode={{ .Values.bsc.gcmode }}
           - --maxpeers={{ .Values.bsc.maxpeers }}
-          - --cache={{ .Values.bsc.cache }}
+          - --cache={{ .Values.bsc.cache.value }}
           - --snapshot={{ .Values.bsc.snapshot }}
           - --persistdiff={{ .Values.bsc.persistdiff }}
           - --diffblock={{ .Values.bsc.diffblock }}
@@ -95,10 +95,10 @@ spec:
           {{- if kindIs "float64" .Values.bsc.txlookuplimit }}
           - --txlookuplimit={{ int .Values.bsc.txlookuplimit }}
           {{- end }}
-          {{- if kindIs "float64" (get .Values.bsc "history.transactions") }}
-          - --history.transactions={{ int (get .Values.bsc "history.transactions") }}
+          {{- if kindIs "float64" .Values.bsc.history.transactions }}
+          - --history.transactions={{ int .Values.bsc.history.transactions }}
           {{- end }}
-          {{- if get .Values.bsc "cache.preimages" }}
+          {{- if .Values.bsc.cache.preimages }}
           - --cache.preimages
           {{- end }}
           {{- if .Values.bsc.wsEnabled }}

--- a/dysnix/bsc/templates/statefulset.yaml
+++ b/dysnix/bsc/templates/statefulset.yaml
@@ -70,7 +70,7 @@ spec:
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       containers:
       - name: {{ .Chart.Name }}
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- if .Values.bscCmdOverride }}
         {{- with .Values.bscCmd }}

--- a/dysnix/bsc/templates/statefulset.yaml
+++ b/dysnix/bsc/templates/statefulset.yaml
@@ -98,7 +98,7 @@ spec:
           {{- if kindIs "float64" (get .Values.bsc "history.transactions") }}
           - --history.transactions={{ int (get .Values.bsc "history.transactions") }}
           {{- end }}
-          {{- if .Values.bsc.preimages }}
+          {{- if get .Values.bsc "cache.preimages" }}
           - --cache.preimages
           {{- end }}
           {{- if .Values.bsc.wsEnabled }}

--- a/dysnix/bsc/templates/statefulset.yaml
+++ b/dysnix/bsc/templates/statefulset.yaml
@@ -86,21 +86,29 @@ spec:
           - --maxpeers={{ .Values.bsc.maxpeers }}
           - --cache={{ .Values.bsc.cache }}
           - --snapshot={{ .Values.bsc.snapshot }}
-          - --pipecommit={{ .Values.bsc.pipecommit }}
           - --persistdiff={{ .Values.bsc.persistdiff }}
           - --diffblock={{ .Values.bsc.diffblock }}
           - --port={{ .Values.service.p2pPort0 }}
+          {{- if .Values.bsc.allowUnprotectedTxs }}
           - --rpc.allow-unprotected-txs
-          - --txlookuplimit=0
+          {{- end }}
+          {{- if kindIs "float64" .Values.bsc.txlookuplimit }}
+          - --txlookuplimit={{ int .Values.bsc.txlookuplimit }}
+          {{- end }}
+          {{- if kindIs "float64" (get .Values.bsc "history.transactions") }}
+          - --history.transactions={{ int (get .Values.bsc "history.transactions") }}
+          {{- end }}
+          {{- if .Values.bsc.preimages }}
           - --cache.preimages
+          {{- end }}
           {{- if .Values.bsc.wsEnabled }}
           - --ws
           {{- end }}
-          {{- if .Values.bsc.diffsync }}
-          - --diffsync
-          {{- end }}
           {{- if .Values.bsc.triesVerifyMode }}
           - --tries-verify-mode={{ .Values.bsc.triesVerifyMode }}
+          {{- end }}
+          {{- if .Values.bsc.pruneancient }}
+          - --pruneancient=true
           {{- end }}
           {{- if and .Values.externalLBp2p .Values.externalLBp2pIP }}
           - --nat=extip:{{- .Values.externalLBp2pIP -}}

--- a/dysnix/bsc/values.yaml
+++ b/dysnix/bsc/values.yaml
@@ -109,8 +109,8 @@ bsc:
   snapshot: false
   allowUnprotectedTxs: true
   preimages: true
-  txlookuplimit: 0            # set this to null and use history.transactions if using BSC >=1.3.x
-  history.transactions: null  # BSC >=1.3.x only
+  txlookuplimit: 0               # WARNING: won't work on BSC >=1.3.x, node will crash if it's provided. use "history.transactions" instead
+  history.transactions: null     # BSC >=1.3.x only
   pruneancient: false
   # extra arguments to pass to container
   extraArgs: []

--- a/dysnix/bsc/values.yaml
+++ b/dysnix/bsc/values.yaml
@@ -105,12 +105,14 @@ bsc:
   wsApi: ["net", "web3", "eth"]
   wsOrigins: ["*"]
   maxpeers: 50
-  cache: 8192
   snapshot: false
   allowUnprotectedTxs: true
-  cache.preimages: true
-  txlookuplimit: 0               # WARNING: won't work on BSC >=1.3.x, node will crash if it's provided. use "history.transactions" instead
-  history.transactions: null     # BSC >=1.3.x only
+  cache:
+    value: 8192
+    preimages: true
+  txlookuplimit: 0               # WARNING: won't work on BSC >=1.3.x, node will crash if it's provided. use ".Values.history.transactions" instead
+  history:
+    transactions: null           # BSC >=1.3.x only
   pruneancient: false
   # extra arguments to pass to container
   extraArgs: []

--- a/dysnix/bsc/values.yaml
+++ b/dysnix/bsc/values.yaml
@@ -8,7 +8,7 @@ terminationGracePeriodSeconds: 180
 
 image:
   repository: ghcr.io/bnb-chain/bsc
-  tag: latest
+  tag: ""
   pullPolicy: Always
 
 imagePullSecrets: []

--- a/dysnix/bsc/values.yaml
+++ b/dysnix/bsc/values.yaml
@@ -99,7 +99,7 @@ bsc:
   gcmode: "full"
   logLevel: "info"
   base_path: "/data"
-  rpcApi: ["eth", "net", "web3", "txpool", "parlia"]
+  rpcApi: ["eth", "net", "web3", "txpool"]
   rpcVhosts: ["*"]
   wsEnabled: false
   wsApi: ["net", "web3", "eth"]

--- a/dysnix/bsc/values.yaml
+++ b/dysnix/bsc/values.yaml
@@ -108,7 +108,7 @@ bsc:
   cache: 8192
   snapshot: false
   allowUnprotectedTxs: true
-  preimages: true
+  cache.preimages: true
   txlookuplimit: 0               # WARNING: won't work on BSC >=1.3.x, node will crash if it's provided. use "history.transactions" instead
   history.transactions: null     # BSC >=1.3.x only
   pruneancient: false

--- a/dysnix/bsc/values.yaml
+++ b/dysnix/bsc/values.yaml
@@ -110,10 +110,10 @@ bsc:
   cache:
     value: 8192
     preimages: true
-  txlookuplimit: 0               # WARNING: won't work on BSC >=1.3.x, node will crash if it's provided. use ".Values.history.transactions" instead
+  txlookuplimit: 0                        # WARNING: won't work on BSC >=1.3.x, node will crash if it's provided. use ".Values.history.transactions" instead
   history:
-    transactions: null           # BSC >=1.3.x only
-  pruneancient: false
+    transactions: null                    # BSC >=1.3.x only
+  pruneancient: false                     # WARNING: enabling this option is irreversible, ancient data will be permanently removed
   # extra arguments to pass to container
   extraArgs: []
   # https://github.com/bnb-chain/bsc/issues/1193

--- a/dysnix/bsc/values.yaml
+++ b/dysnix/bsc/values.yaml
@@ -107,8 +107,11 @@ bsc:
   maxpeers: 50
   cache: 8192
   snapshot: false
-  pipecommit: false
-  diffsync: true
+  allowUnprotectedTxs: true
+  preimages: true
+  txlookuplimit: 0            # set this to null and use history.transactions if using BSC >=1.3.x
+  history.transactions: null  # BSC >=1.3.x only
+  pruneancient: false
   # extra arguments to pass to container
   extraArgs: []
   # https://github.com/bnb-chain/bsc/issues/1193


### PR DESCRIPTION
This PR will remove deprecated `--pipecommit` and `--diffsync` while also introducing some extra arguments:

- `--cache.preimages` is now configurable
- `--txlookuplimit` is now configurable for BSC 1.2.x and older versions, set to `null` to be omitted
- `--history.transactions` is now available for BSC >=1.3.x, replacing `--txlookuplimit` argument, by default disabled
- `--pruneancient` is now available