### PR TITLE
[nifi-registry] Made compatible with apache/nifi >= 1.19.0

### DIFF
--- a/dysnix/nifi-registry/Chart.yaml
+++ b/dysnix/nifi-registry/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.4
+version: 1.1.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/dysnix/nifi-registry/templates/statefulset.yaml
+++ b/dysnix/nifi-registry/templates/statefulset.yaml
@@ -125,6 +125,7 @@ spec:
                         -noprompt \
                         -trustcacerts \
                         -alias $ALIAS \
+                        -storetype JKS \
                         -file $ca \
                         -keystore "${NIFI_REGISTRY_HOME}/tls/truststore.jks" \
                         -storepass "{{ .Values.certManager.truststorePasswd }}"
@@ -142,6 +143,7 @@ spec:
                       -destkeystore "${NIFI_REGISTRY_HOME}/tls/keystore.jks" \
                       -srckeystore "/tmp/tls.p12" \
                       -srcstoretype PKCS12 \
+                      -deststoretype JKS \
                       -srcstorepass "{{ .Values.certManager.keystorePasswd }}" \
                       -deststorepass "{{ .Values.certManager.keystorePasswd }}"
               keytool -list -keystore "${NIFI_REGISTRY_HOME}/tls/keystore.jks" \


### PR DESCRIPTION
This bugfix is completely analogous to the pull request https://github.com/cetic/helm-nifi/pull/314.

This pull request allows apache/nifi-registry versions >=0.19.0 to be released with this helm chart.

As described in issue https://github.com/cetic/helm-nifi/issues/313, this only required the keystore type to be explicitly set to JKS when calling keytool to be compatible with Java 11.

This change is backward compatible with Java 8.