### PR TITLE
[ProxySQL] lifecycle improvements

### DIFF
--- a/dysnix/proxysql/Chart.yaml
+++ b/dysnix/proxysql/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: "2.5.5"
 description: ProxySQL Helm chart for Kubernetes
 name: proxysql
-version: 0.11.0
+version: 0.11.1
 home: https://www.proxysql.com/
 sources:
   - https://github.com/dysnix/charts

--- a/dysnix/proxysql/Chart.yaml
+++ b/dysnix/proxysql/Chart.yaml
@@ -1,5 +1,6 @@
+---
 apiVersion: v1
-appVersion: "2.4.4"
+appVersion: "2.5.5"
 description: ProxySQL Helm chart for Kubernetes
 name: proxysql
 version: 0.10.1

--- a/dysnix/proxysql/Chart.yaml
+++ b/dysnix/proxysql/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: "2.5.5"
 description: ProxySQL Helm chart for Kubernetes
 name: proxysql
-version: 0.10.1
+version: 0.11.0
 home: https://www.proxysql.com/
 sources:
   - https://github.com/dysnix/charts

--- a/dysnix/proxysql/Chart.yaml
+++ b/dysnix/proxysql/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: "2.5.5"
 description: ProxySQL Helm chart for Kubernetes
 name: proxysql
-version: 0.11.1
+version: 0.11.2
 home: https://www.proxysql.com/
 sources:
   - https://github.com/dysnix/charts

--- a/dysnix/proxysql/files/proxysql_cluster_healthcheck.sh
+++ b/dysnix/proxysql/files/proxysql_cluster_healthcheck.sh
@@ -7,43 +7,46 @@ DB_USER="${DB_USER:-monitor}"
 DB_HOST="${DB_HOST:-127.0.0.1}"
 DB_PORT="${DB_PORT:-6032}"
 
+# Health check configuration with default values
 PROXYSQL_DIFF_CHECK_LIMIT=${PROXYSQL_DIFF_CHECK_LIMIT:-10}
 PROXYSQL_KILL_IF_HEALTCHECK_FAILED=${PROXYSQL_KILL_IF_HEALTCHECK_FAILED:-true}
 PROXYSQL_HEALTH_CHECK_FAILURES=${PROXYSQL_HEALTH_CHECK_FAILURES:-3}
 
 export MYSQL_PWD="${DB_PASS:-monitor}"
 
+# Locate mysql or mariadb client binary
+function find_mysql_client() {
+    if command -v mysql >/dev/null 2>&1; then
+        echo "mysql"
+    elif command -v mariadb >/dev/null 2>&1; then
+        echo "mariadb"
+    else
+        echo "[$(date -Ins)] [ERROR] Neither 'mysql' nor 'mariadb' client is installed." >&2
+        exit 1
+    fi
+}
+
+MYSQL_CLIENT=$(find_mysql_client)
+
 function mysql_cli() {
-  mysql -u ${DB_USER} -h ${DB_HOST} -P ${DB_PORT} --skip-column-names --batch --ssl-mode=DISABLED -e "$1"
+  $MYSQL_CLIENT -u "$DB_USER" -h "$DB_HOST" -P "$DB_PORT" --skip-column-names --batch --ssl-mode=DISABLED -e "$1"
 }
 
 function run_diff_check_count() {
-  DIFF_CHECK_COUNT=$(mysql_cli "SELECT COUNT(diff_check) FROM stats_proxysql_servers_checksums WHERE diff_check > ${PROXYSQL_DIFF_CHECK_LIMIT};")
+  local diff_check_count
+  diff_check_count=$(mysql_cli "SELECT COUNT(diff_check) FROM stats_proxysql_servers_checksums WHERE diff_check > $PROXYSQL_DIFF_CHECK_LIMIT;")
 
-  if [[ "${DIFF_CHECK_COUNT}" == 0 ]]; then
-    echo "[$(date -Ins)] [INFO] ProxySQL Cluster diff_check OK. diff_check < ${PROXYSQL_DIFF_CHECK_LIMIT}"
+  if [[ "$diff_check_count" == 0 ]]; then
+    echo "[$(date -Ins)] [INFO] ProxySQL Cluster diff_check OK. diff_check < $PROXYSQL_DIFF_CHECK_LIMIT"
+    return 0
   else
-    RESULT=$(mysql_cli "SELECT hostname, port, name, version, FROM_UNIXTIME(epoch) epoch, checksum, FROM_UNIXTIME(changed_at) changed_at, FROM_UNIXTIME(updated_at) updated_at, diff_check, DATETIME('NOW') FROM stats_proxysql_servers_checksums WHERE diff_check > ${PROXYSQL_DIFF_CHECK_LIMIT} ORDER BY name;")
-    echo "${RESULT}"
-
-    if [[ ${PROXYSQL_HEALTH_CHECK_FAILURES} -le 3 ]]; then
-      echo "[$(date -Ins)] [WARN] ProxySQL Cluster diff_check WARNING. diff_check >= ${PROXYSQL_DIFF_CHECK_LIMIT}. Failure count = ${PROXYSQL_HEALTH_CHECK_FAILURES}"
-      PROXYSQL_HEALTH_CHECK_FAILURES=$(( PROXYSQL_HEALTH_CHECK_FAILURES + 1 ))
-    else
-      if [[ "${PROXYSQL_KILL_IF_HEALTCHECK_FAILED}" == "true" ]]; then
-        echo "[$(date -Ins)] [ERROR] Terminating proxysql process... diff_check >= ${PROXYSQL_DIFF_CHECK_LIMIT}. Failure count = ${PROXYSQL_HEALTH_CHECK_FAILURES}"
-        kill -s SIGTERM "$(pidof proxysql)"
-      fi
-      BACKOFF_SLEEP_TIME=$[ ( $RANDOM % 60 )  + 30 ]
-      echo "[$(date -Ins)] [WARN] ProxySQL health check exiting in ${BACKOFF_SLEEP_TIME} seconds..."
-      sleep ${BACKOFF_SLEEP_TIME}s
-      exit 1
-    fi
+    local result
+    result=$(mysql_cli "SELECT hostname, port, name, version, FROM_UNIXTIME(epoch) epoch, checksum, FROM_UNIXTIME(changed_at) changed_at, FROM_UNIXTIME(updated_at) updated_at, diff_check, DATETIME('NOW') FROM stats_proxysql_servers_checksums WHERE diff_check > $PROXYSQL_DIFF_CHECK_LIMIT ORDER BY name;")
+    echo "$result"
+    echo "[$(date -Ins)] [ERROR] ProxySQL Cluster diff_check CRITICAL. diff_check >= $PROXYSQL_DIFF_CHECK_LIMIT." >&2
+    return 1
   fi
 }
 
-echo "[$(date -Ins)] [INFO] ProxySQL health check start..."
-while true; do
-  sleep $[ ( $RANDOM % 7 )  + 3 ]s
-  run_diff_check_count
-done
+# Call the health check function once for Kubernetes probes
+run_diff_check_count

--- a/dysnix/proxysql/files/proxysql_cluster_healthcheck.sh
+++ b/dysnix/proxysql/files/proxysql_cluster_healthcheck.sh
@@ -29,7 +29,7 @@ function find_mysql_client() {
 MYSQL_CLIENT=$(find_mysql_client)
 
 function mysql_cli() {
-  $MYSQL_CLIENT -u "$DB_USER" -h "$DB_HOST" -P "$DB_PORT" --skip-column-names --batch --ssl-mode=DISABLED -e "$1"
+  $MYSQL_CLIENT -u "$DB_USER" -h "$DB_HOST" -P "$DB_PORT" --skip-column-names --batch -e "$1"
 }
 
 function run_diff_check_count() {

--- a/dysnix/proxysql/files/proxysql_cluster_healthcheck.sh
+++ b/dysnix/proxysql/files/proxysql_cluster_healthcheck.sh
@@ -57,7 +57,7 @@ function run_diff_check_count() {
   else
     log_error "ProxySQL Cluster diff_check CRITICAL. diff_check >= $PROXYSQL_HEALTHCHECK_DIFF_CHECK_LIMIT."
     get_current_proxysql_state
-    return 1
+    exit 1
   fi
 }
 
@@ -78,7 +78,7 @@ function run_valid_config_count() {
   else
     log_error "ProxySQL Cluster config version and checksum CRITICAL. valid_config_count ${valid_config_count} < 1"
     get_current_proxysql_state
-    return 1
+    exit 1
   fi
 }
 

--- a/dysnix/proxysql/files/proxysql_cluster_healthcheck.sh
+++ b/dysnix/proxysql/files/proxysql_cluster_healthcheck.sh
@@ -10,8 +10,6 @@ export MYSQL_PWD="${PROXYSQL_HEALTHCHECK_DB_PASS:-monitor}"
 
 # Health check configuration with default values
 PROXYSQL_HEALTHCHECK_DIFF_CHECK_LIMIT=${PROXYSQL_HEALTHCHECK_DIFF_CHECK_LIMIT:-10}
-PROXYSQL_HEALTHCHECK_KILL_IF_HEALTCHECK_FAILED=${PROXYSQL_HEALTHCHECK_KILL_IF_HEALTCHECK_FAILED:-true}
-PROXYSQL_HEALTHCHECK_FAILURE_THRESHOLD=${PROXYSQL_HEALTHCHECK_FAILURE_THRESHOLD:-3}
 
 # Locate mysql or mariadb client binary
 function find_mysql_client() {
@@ -20,12 +18,20 @@ function find_mysql_client() {
     elif command -v mariadb >/dev/null 2>&1; then
         echo "mariadb"
     else
-        echo "[$(date -Ins)] [ERROR] Neither 'mysql' nor 'mariadb' client is installed." >&2
+        log_error "Neither 'mysql' nor 'mariadb' client is installed."
         exit 1
     fi
 }
 
 MYSQL_CLIENT=$(find_mysql_client)
+
+function log_info() {
+  echo "[$(date -Ins)] [INFO] $1"
+}
+
+function log_error() {
+  echo "[$(date -Ins)] [ERROR] $1" >&2
+}
 
 function mysql_cli() {
   $MYSQL_CLIENT -u "$DB_USER" -h "$DB_HOST" -P "$DB_PORT" --skip-column-names --batch -e "$1"
@@ -36,13 +42,13 @@ function run_diff_check_count() {
   diff_check_count=$(mysql_cli "SELECT COUNT(diff_check) FROM stats_proxysql_servers_checksums WHERE diff_check > $PROXYSQL_HEALTHCHECK_DIFF_CHECK_LIMIT;")
 
   if [[ "$diff_check_count" == 0 ]]; then
-    echo "[$(date -Ins)] [INFO] ProxySQL Cluster diff_check OK. diff_check < $PROXYSQL_HEALTHCHECK_DIFF_CHECK_LIMIT"
+    log_info "ProxySQL Cluster diff_check OK. diff_check < $PROXYSQL_HEALTHCHECK_DIFF_CHECK_LIMIT"
     return 0
   else
     local result
     result=$(mysql_cli "SELECT hostname, port, name, version, FROM_UNIXTIME(epoch) epoch, checksum, FROM_UNIXTIME(changed_at) changed_at, FROM_UNIXTIME(updated_at) updated_at, diff_check, DATETIME('NOW') FROM stats_proxysql_servers_checksums WHERE diff_check > $PROXYSQL_HEALTHCHECK_DIFF_CHECK_LIMIT ORDER BY name;")
     echo "$result"
-    echo "[$(date -Ins)] [ERROR] ProxySQL Cluster diff_check CRITICAL. diff_check >= $PROXYSQL_HEALTHCHECK_DIFF_CHECK_LIMIT." >&2
+    log_error "ProxySQL Cluster diff_check CRITICAL. diff_check >= $PROXYSQL_HEALTHCHECK_DIFF_CHECK_LIMIT."
     return 1
   fi
 }

--- a/dysnix/proxysql/files/wait_queries_to_finish.sh
+++ b/dysnix/proxysql/files/wait_queries_to_finish.sh
@@ -1,29 +1,60 @@
 #!/usr/bin/env bash
 
-# For all proxysql processes iterate over all tcp connections
-# and search for any established connection to port ${PROXYSQL_SERVICE_PORT_PROXY:-6033}.
-# If more than one connection is found, randomly sleep up to 3 seconds,
-# otherwise exit 0.
+# This script continuously monitors for active TCP connections to a specified ProxySQL service port
+# and, if any are found, it pauses execution for a random duration between one and three seconds
+# before checking again. It exits when there are no more active connections to the specified port.
 
-set -u
+set -euo pipefail
 
-echo "Waiting for proxy queries to finish..."
+PROXYSQL_SERVICE_PORT=${PROXYSQL_SERVICE_PORT_PROXY:-6033}
+SLEEP_MAX=3 # Maximum sleep duration in seconds.
+HEX_PORT=$(printf ':%04X' $PROXYSQL_SERVICE_PORT) # Convert the port number to a padded hexadecimal string.
 
+echo "Waiting for ProxySQL queries to finish..."
+
+# Retrieves IP addresses of established connections to the ProxySQL service port
+function get_connected_ips() {
+  local connected_ips=()
+  # Loop over all proxysql process IDs
+  for pid in $(pidof proxysql 2>/dev/null || echo ""); do
+    # Read related tcp connection information, filter by established connections on proxy port, extract IPs, and remove duplicates
+    while read -r ip; do
+      connected_ips+=("$ip")
+    done < <(awk 'toupper($0) ~ /'"$HEX_PORT"' [0-9A-F]+:[0-9A-F]+ 01/ {print substr($3,1,length($3)-5)}' /proc/${pid}/net/tcp | sort -u)
+  done
+  echo "${connected_ips[@]}"
+}
+
+# Converts a hexadecimal IP address to its decimal representation
+function convert_hex_ip_to_decimal() {
+  local hex_ip=$1
+  local dec_ip=""
+
+  # Handle endianness and convert each pair of hex characters to decimal
+  for i in {6..1..2}; do
+    dec_ip+=".$((16#${hex_ip:i-2:2}))"
+  done
+  echo "${dec_ip:1}" # Remove the leading dot before returning the decimal IP
+}
+
+# Main loop that checks for and handles active ProxySQL connections
 while true; do
-  CONNECTED_IPS=$(for pid in $(pidof proxysql); do \
-    cat /proc/${pid}/net/tcp \
-    | grep -E "[[:digit:]]+: [[:xdigit:]]+$(printf ':%x' ${PROXYSQL_SERVICE_PORT_PROXY:-6033}) [[:xdigit:]]+:[[:xdigit:]]+ 01" \
-    | sort -u \
-    | cut -f1 -d':' \
-    | awk '{gsub(/../,"0x& ")} OFS="." {for(i=NF;i>0;i--) printf "%d%s", $i, (i == 1 ? ORS : OFS)}'; \
-    done )
+  connected_ips_hex=( $(get_connected_ips) ) # Retrieve list of currently connected IP addresses in hexadecimal format
 
-  echo "Connected IPs: $(echo ${CONNECTED_IPS} | wc -l)"
-  if [[ -z ${CONNECTED_IPS} ]]; then
-    echo "Done. Exiting...";
+  # If no connections are found, then exit
+  if [ ${#connected_ips_hex[@]} -eq 0 ]; then
+    echo "Done. Exiting..."
     exit 0
-  else
-    echo "Sleeping...";
-    sleep $[ ( $RANDOM % 3 )  + 1 ]s
-  fi;
+  fi
+
+  # Convert all hexadecimal IP addresses to decimal notation
+  connected_ips_dec=()
+  for ip_hex in "${connected_ips_hex[@]}"; do
+    connected_ips_dec+=( "$(convert_hex_ip_to_decimal "$ip_hex")" )
+  done
+
+  # Print the number of unique connected IPs
+  echo "Connected IPs: ${#connected_ips_dec[@]}"
+  echo "Sleeping..."
+  sleep $(( RANDOM % SLEEP_MAX + 1 ))
 done

--- a/dysnix/proxysql/templates/_helpers.tpl
+++ b/dysnix/proxysql/templates/_helpers.tpl
@@ -75,7 +75,7 @@ Return the proper ProxySQL image name
 {{- define "proxysql.image" -}}
 {{- $registryName := .Values.image.registry -}}
 {{- $repositoryName := .Values.image.repository -}}
-{{- $tag := .Values.image.tag | toString -}}
+{{- $tag := (.Values.image.tag | default .Chart.AppVersion) | toString -}}
   {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
 {{- end -}}
 

--- a/dysnix/proxysql/templates/configmap-healthcheck.yaml
+++ b/dysnix/proxysql/templates/configmap-healthcheck.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.proxysql_cluster.healthcheck.sidecar.enabled }}
+{{- if or .Values.readinessProbe.enabled .Values.livenessProbe.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -6,9 +6,9 @@ metadata:
   labels:
     {{- include "proxysql.labels" . | nindent 4 }}
 data: 
-  DB_USER: {{ .Values.proxysql_cluster.healthcheck.sidecar.config.psql_user | quote }}
-  DB_HOST: {{ .Values.proxysql_cluster.healthcheck.sidecar.config.psql_host | quote }}
-  DB_PORT: {{ .Values.proxysql_cluster.healthcheck.sidecar.config.psql_host_port | quote }}
-  PROXYSQL_DIFF_CHECK_LIMIT: {{ .Values.proxysql_cluster.healthcheck.sidecar.config.diff_check_limit | quote }}
-  PROXYSQL_KILL_IF_HEALTCHECK_FAILED: {{ .Values.proxysql_cluster.healthcheck.sidecar.config.kill_if_healthcheck_failed | quote }}
+  PROXYSQL_HEALTHCHECK_DB_USER: {{ .Values.proxysql_cluster.healthcheck.psql_user | default .Values.mysql_variables.monitor_username | quote }}
+  PROXYSQL_HEALTHCHECK_DB_HOST: {{ .Values.proxysql_cluster.healthcheck.psql_host | quote }}
+  PROXYSQL_HEALTHCHECK_DB_PORT: {{ .Values.proxysql_cluster.healthcheck.psql_host_port | default .Values.service.adminPort | quote }}
+  PROXYSQL_HEALTHCHECK_DIFF_CHECK_LIMIT: {{ .Values.proxysql_cluster.healthcheck.diff_check_limit | quote }}
+  PROXYSQL_HEALTHCHECK_KILL_IF_HEALTCHECK_FAILED: {{ .Values.proxysql_cluster.healthcheck.kill_if_healthcheck_failed | quote }}
 {{- end }}

--- a/dysnix/proxysql/templates/configmap-healthcheck.yaml
+++ b/dysnix/proxysql/templates/configmap-healthcheck.yaml
@@ -11,4 +11,5 @@ data:
   PROXYSQL_HEALTHCHECK_DB_PORT: {{ .Values.proxysql_cluster.healthcheck.psql_host_port | default .Values.service.adminPort | quote }}
   PROXYSQL_HEALTHCHECK_DIFF_CHECK_LIMIT: {{ .Values.proxysql_cluster.healthcheck.diff_check_limit | quote }}
   PROXYSQL_HEALTHCHECK_KILL_IF_HEALTCHECK_FAILED: {{ .Values.proxysql_cluster.healthcheck.kill_if_healthcheck_failed | quote }}
+  PROXYSQL_HEALTHCHECK_VERBOSE: {{ .Values.proxysql_cluster.healthcheck.verbose | quote }}
 {{- end }}

--- a/dysnix/proxysql/templates/configmap-healthcheck.yaml
+++ b/dysnix/proxysql/templates/configmap-healthcheck.yaml
@@ -1,4 +1,5 @@
 {{- if or .Values.readinessProbe.enabled .Values.livenessProbe.enabled }}
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/dysnix/proxysql/templates/daemonset.yaml
+++ b/dysnix/proxysql/templates/daemonset.yaml
@@ -69,7 +69,7 @@ spec:
           lifecycle:
             preStop:
               exec:
-                command: ["/bin/sh", "-c", "/usr/local/bin/wait_queries_to_finish.sh > /proc/1/fd/1"]
+                command: ["/bin/sh", "-c", "/usr/local/bin/wait_queries_to_finish.sh"]
           ports:
             - name: proxy
               containerPort: {{ .Values.service.proxyPort }}
@@ -93,7 +93,7 @@ spec:
           {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
             exec:
-              command: {{ .Values.proxysql_cluster.healthcheck.command }}
+              command: {{ .Values.proxysql_cluster.healthcheck.command | toYaml | nindent 16 }}
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
@@ -103,7 +103,7 @@ spec:
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             exec:
-              command: {{ .Values.proxysql_cluster.healthcheck.command }}
+              command: {{ .Values.proxysql_cluster.healthcheck.command | toYaml | nindent 16 }}
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}

--- a/dysnix/proxysql/templates/daemonset.yaml
+++ b/dysnix/proxysql/templates/daemonset.yaml
@@ -55,6 +55,13 @@ spec:
             {{- if .Values.proxysql_cluster.satellite.exit_on_error }}
             - "--exit-on-error"
             {{- end }}
+          envFrom:
+          {{- if or .Values.readinessProbe.enabled .Values.livenessProbe.enabled }}
+            - configMapRef:
+                name: '{{ include "proxysql.fullname" . }}-healthcheck'
+            - secretRef:
+                name: '{{ include "proxysql.fullname" . }}-healthcheck'
+          {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: {{ template "proxysql.image" . }}

--- a/dysnix/proxysql/templates/daemonset.yaml
+++ b/dysnix/proxysql/templates/daemonset.yaml
@@ -93,7 +93,7 @@ spec:
           {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
             exec:
-              command: ["/usr/local/bin/proxysql_cluster_healthcheck.sh"]
+              command: {{ .Values.proxysql_cluster.healthcheck.command }}
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
@@ -103,7 +103,7 @@ spec:
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             exec:
-              command: ["/usr/local/bin/proxysql_cluster_healthcheck.sh"]
+              command: {{ .Values.proxysql_cluster.healthcheck.command }}
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}

--- a/dysnix/proxysql/templates/daemonset.yaml
+++ b/dysnix/proxysql/templates/daemonset.yaml
@@ -157,25 +157,6 @@ spec:
             {{- toYaml .| nindent 12 }}
           {{- end }}
         {{- end }}
-        {{- if and .Values.proxysql_cluster.enabled .Values.proxysql_cluster.healthcheck.sidecar.enabled }}
-        - name: healthcheck
-          image: {{ .Values.proxysql_cluster.healthcheck.sidecar.image }}
-          command:
-            {{- toYaml .Values.proxysql_cluster.healthcheck.sidecar.command | nindent 14 }}
-          envFrom:
-            - configMapRef:
-                name: '{{ include "proxysql.fullname" . }}-healthcheck'
-            - secretRef:
-                name: '{{ include "proxysql.fullname" . }}-healthcheck'
-          volumeMounts:
-            - name: scripts
-              mountPath: /usr/local/bin/proxysql_cluster_healthcheck.sh
-              subPath: proxysql_cluster_healthcheck.sh
-          {{- with .Values.proxysql_cluster.healthcheck.sidecar.securityContext }}
-          securityContext:
-            {{- toYaml .| nindent 12 }}
-          {{- end }}
-        {{- end }}
       {{- with (default .Values.nodeSelector .Values.proxysql_cluster.satellite.daemonset.nodeSelector) }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/dysnix/proxysql/templates/daemonset.yaml
+++ b/dysnix/proxysql/templates/daemonset.yaml
@@ -73,15 +73,15 @@ spec:
             - name: web
               containerPort: {{ .Values.service.webPort }}
               protocol: TCP
-          {{- if .Values.readinessProbe.enabled }}
-          readinessProbe:
+          {{- if .Values.startupProbe.enabled }}
+          startupProbe:
             exec:
               command: ["bash", "-c", "true <>/dev/tcp/127.0.0.1/{{ .Values.service.proxyPort }}"]
-            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.readinessProbe.successThreshold }}
-            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+            initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.startupProbe.successThreshold }}
+            failureThreshold: {{ .Values.startupProbe.failureThreshold }}
           {{- end }}
           resources:
             {{- toYaml (default .Values.resources .Values.proxysql_cluster.satellite.daemonset.resources) | nindent 12 }}

--- a/dysnix/proxysql/templates/daemonset.yaml
+++ b/dysnix/proxysql/templates/daemonset.yaml
@@ -83,6 +83,26 @@ spec:
             successThreshold: {{ .Values.startupProbe.successThreshold }}
             failureThreshold: {{ .Values.startupProbe.failureThreshold }}
           {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
+          readinessProbe:
+            exec:
+              command: ["/usr/local/bin/proxysql_cluster_healthcheck.sh"]
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.livenessProbe.enabled }}
+          livenessProbe:
+            exec:
+              command: ["/usr/local/bin/proxysql_cluster_healthcheck.sh"]
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          {{- end }}
           resources:
             {{- toYaml (default .Values.resources .Values.proxysql_cluster.satellite.daemonset.resources) | nindent 12 }}
           volumeMounts:
@@ -97,6 +117,9 @@ spec:
             - name: scripts
               mountPath: /usr/local/bin/wait_queries_to_finish.sh
               subPath: wait_queries_to_finish.sh
+            - name: scripts
+              mountPath: /usr/local/bin/proxysql_cluster_healthcheck.sh
+              subPath: proxysql_cluster_healthcheck.sh
           {{- if .Values.ssl.fromSecret }}
             - name: ssl
               mountPath: /etc/proxysql/ssl

--- a/dysnix/proxysql/templates/deployment.yaml
+++ b/dysnix/proxysql/templates/deployment.yaml
@@ -84,6 +84,26 @@ spec:
             successThreshold: {{ .Values.startupProbe.successThreshold }}
             failureThreshold: {{ .Values.startupProbe.failureThreshold }}
           {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
+          readinessProbe:
+            exec:
+              command: ["/usr/local/bin/proxysql_cluster_healthcheck.sh"]
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.livenessProbe.enabled }}
+          livenessProbe:
+            exec:
+              command: ["/usr/local/bin/proxysql_cluster_healthcheck.sh"]
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
@@ -98,6 +118,9 @@ spec:
             - name: scripts
               mountPath: /usr/local/bin/wait_queries_to_finish.sh
               subPath: wait_queries_to_finish.sh
+            - name: scripts
+              mountPath: /usr/local/bin/proxysql_cluster_healthcheck.sh
+              subPath: proxysql_cluster_healthcheck.sh
           {{- if .Values.ssl.fromSecret }}
             - name: ssl
               mountPath: /etc/proxysql/ssl

--- a/dysnix/proxysql/templates/deployment.yaml
+++ b/dysnix/proxysql/templates/deployment.yaml
@@ -94,7 +94,7 @@ spec:
           {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
             exec:
-              command: ["/usr/local/bin/proxysql_cluster_healthcheck.sh"]
+              command: {{ .Values.proxysql_cluster.healthcheck.command }}
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
@@ -104,7 +104,7 @@ spec:
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             exec:
-              command: ["/usr/local/bin/proxysql_cluster_healthcheck.sh"]
+              command: {{ .Values.proxysql_cluster.healthcheck.command }}
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}

--- a/dysnix/proxysql/templates/deployment.yaml
+++ b/dysnix/proxysql/templates/deployment.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- toYaml .Values.commonAnnotations | nindent 4 }}
   {{- end }}
 spec:
-  replicas: {{ .Values.replicas }}
+  replicas: {{ .Values.proxysql_cluster.satellite.replicas }}
   selector:
     matchLabels:
       {{- include "proxysql.satellite.selectorLabels" . | nindent 6 }}

--- a/dysnix/proxysql/templates/deployment.yaml
+++ b/dysnix/proxysql/templates/deployment.yaml
@@ -158,25 +158,6 @@ spec:
             {{- toYaml .| nindent 12 }}
           {{- end }}
         {{- end }}
-        {{- if and .Values.proxysql_cluster.enabled .Values.proxysql_cluster.healthcheck.sidecar.enabled }}
-        - name: healthcheck
-          image: {{ .Values.proxysql_cluster.healthcheck.sidecar.image }}
-          command:
-            {{- toYaml .Values.proxysql_cluster.healthcheck.sidecar.command | nindent 14 }}
-          envFrom:
-            - configMapRef:
-                name: '{{ include "proxysql.fullname" . }}-healthcheck'
-            - secretRef:
-                name: '{{ include "proxysql.fullname" . }}-healthcheck'
-          volumeMounts:
-            - name: scripts
-              mountPath: /usr/local/bin/proxysql_cluster_healthcheck.sh
-              subPath: proxysql_cluster_healthcheck.sh
-          {{- with .Values.proxysql_cluster.healthcheck.sidecar.securityContext }}
-          securityContext:
-            {{- toYaml .| nindent 12 }}
-          {{- end }}
-        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/dysnix/proxysql/templates/deployment.yaml
+++ b/dysnix/proxysql/templates/deployment.yaml
@@ -56,6 +56,13 @@ spec:
             {{- if .Values.proxysql_cluster.satellite.exit_on_error }}
             - "--exit-on-error"
             {{- end }}
+          envFrom:
+          {{- if or .Values.readinessProbe.enabled .Values.livenessProbe.enabled }}
+            - configMapRef:
+                name: '{{ include "proxysql.fullname" . }}-healthcheck'
+            - secretRef:
+                name: '{{ include "proxysql.fullname" . }}-healthcheck'
+          {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: {{ template "proxysql.image" . }}

--- a/dysnix/proxysql/templates/deployment.yaml
+++ b/dysnix/proxysql/templates/deployment.yaml
@@ -70,7 +70,7 @@ spec:
           lifecycle:
             preStop:
               exec:
-                command: ["/bin/sh", "-c", "/usr/local/bin/wait_queries_to_finish.sh > /proc/1/fd/1"]
+                command: ["/bin/sh", "-c", "/usr/local/bin/wait_queries_to_finish.sh"]
           ports:
             - name: proxy
               containerPort: {{ .Values.service.proxyPort }}
@@ -94,7 +94,7 @@ spec:
           {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
             exec:
-              command: {{ .Values.proxysql_cluster.healthcheck.command }}
+              command: {{ .Values.proxysql_cluster.healthcheck.command | toYaml | nindent 16 }}
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
@@ -104,7 +104,7 @@ spec:
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             exec:
-              command: {{ .Values.proxysql_cluster.healthcheck.command }}
+              command: {{ .Values.proxysql_cluster.healthcheck.command | toYaml | nindent 16 }}
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}

--- a/dysnix/proxysql/templates/deployment.yaml
+++ b/dysnix/proxysql/templates/deployment.yaml
@@ -74,15 +74,15 @@ spec:
             - name: web
               containerPort: {{ .Values.service.webPort }}
               protocol: TCP
-          {{- if .Values.readinessProbe.enabled }}
-          readinessProbe:
+          {{- if .Values.startupProbe.enabled }}
+          startupProbe:
             exec:
               command: ["bash", "-c", "true <>/dev/tcp/127.0.0.1/{{ .Values.service.proxyPort }}"]
-            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.readinessProbe.successThreshold }}
-            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+            initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.startupProbe.successThreshold }}
+            failureThreshold: {{ .Values.startupProbe.failureThreshold }}
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/dysnix/proxysql/templates/jobs.yaml
+++ b/dysnix/proxysql/templates/jobs.yaml
@@ -1,5 +1,7 @@
 {{- if and .Values.proxysql_cluster.enabled .Values.proxysql_cluster.job.enabled .Values.proxysql_cluster.core.enabled }}
-{{- $coreServiceName := printf "%s-core" (include "proxysql.fullname" .) }}
+---
+{{- $coreServiceName := printf "%s-core.%s.svc" (include "proxysql.fullname" .) .Release.Namespace }}
+{{- $coreServiceAdminPort := (.Values.proxysql_cluster.healthcheck.psql_host_port | default .Values.service.adminPort) }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -53,19 +55,29 @@ spec:
       initContainers:
         {{/* Wait for proxysql admin DB to show up */}}
         - name: wait-for-proxysql-admin
-          image: busybox:latest
-          imagePullPolicy: Always
-          command: ["/bin/sh" ]
-          args: ["-c",
-                 "until nc -vz {{ $coreServiceName }} 6032; do echo 'Waiting for DB...'; sleep 3s; done;"]
+          image: {{ template "proxysql.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["/bin/bash" ]
+          args:
+            - "-c"
+            - |
+                until true <>/dev/tcp/{{ $coreServiceName }}/{{ $coreServiceAdminPort }}; do
+                  echo "Waiting for {{ $coreServiceName }}:{{ $coreServiceAdminPort }} node...";
+                  sleep 3s;
+                done;
+                echo "Success connecting to {{ $coreServiceName }}:{{ $coreServiceAdminPort }}";
       containers:
-        - name: "psql-init-cluster"
+        - name: "psql-init-update-cluster-checksums"
           {{/* Connect to the ProxySQL console and execute the SQL script `/data/update-cluster-checksums.sql` */}}
-          command: ["/bin/sh" ]
-          args: [ "-c",
-                  "mysql --user=${PSQL_USER} --password=${PSQL_PASSWORD} --host={{ $coreServiceName }} --port=6032 --wait -vv < /data/update-cluster-checksums.sql" ]
-          image: {{ template "proxysql.proxysql_cluster.job.image" . }}
-          imagePullPolicy: {{ .Values.proxysql_cluster.job.image.pullPolicy }}
+          image: {{ template "proxysql.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["/bin/bash"]
+          args:
+            - "-c"
+            - >
+                mysql --user=${PSQL_USER} --password=${PSQL_PASSWORD}
+                --host={{ $coreServiceName }} --port={{ $coreServiceAdminPort }}
+                --wait -vv < /data/update-cluster-checksums.sql
           resources:
             {{- toYaml (default .Values.resources .Values.proxysql_cluster.job.resources) | nindent 12 }}
           env:

--- a/dysnix/proxysql/templates/secret-healthcheck.yaml
+++ b/dysnix/proxysql/templates/secret-healthcheck.yaml
@@ -6,5 +6,5 @@ metadata:
   labels:
     {{- include "proxysql.labels" . | nindent 4 }}
 data:
-  DB_PASS: {{ .Values.proxysql_cluster.healthcheck.sidecar.config.psql_pass | default "" | b64enc | quote }}
+  PROXYSQL_HEALTHCHECK_DB_PASS: {{ .Values.proxysql_cluster.healthcheck.psql_pass | default .Values.mysql_variables.monitor_password | default "" | b64enc | quote }}
 {{- end }}

--- a/dysnix/proxysql/templates/secret-healthcheck.yaml
+++ b/dysnix/proxysql/templates/secret-healthcheck.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.proxysql_cluster.healthcheck.sidecar.enabled }}
+{{- if or .Values.readinessProbe.enabled .Values.livenessProbe.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/dysnix/proxysql/templates/statefullset.yaml
+++ b/dysnix/proxysql/templates/statefullset.yaml
@@ -85,6 +85,26 @@ spec:
             successThreshold: {{ .Values.startupProbe.successThreshold }}
             failureThreshold: {{ .Values.startupProbe.failureThreshold }}
           {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
+          readinessProbe:
+            exec:
+              command: ["/usr/local/bin/proxysql_cluster_healthcheck.sh"]
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.livenessProbe.enabled }}
+          livenessProbe:
+            exec:
+              command: ["/usr/local/bin/proxysql_cluster_healthcheck.sh"]
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          {{- end }}
           resources:
             {{- toYaml (default .Values.resources .Values.proxysql_cluster.core.statefullset.resources) | nindent 12 }}
           volumeMounts:
@@ -99,6 +119,9 @@ spec:
             - name: scripts
               mountPath: /usr/local/bin/wait_queries_to_finish.sh
               subPath: wait_queries_to_finish.sh
+            - name: scripts
+              mountPath: /usr/local/bin/proxysql_cluster_healthcheck.sh
+              subPath: proxysql_cluster_healthcheck.sh
           {{- if .Values.ssl.fromSecret }}
             - name: ssl
               mountPath: /etc/proxysql/ssl

--- a/dysnix/proxysql/templates/statefullset.yaml
+++ b/dysnix/proxysql/templates/statefullset.yaml
@@ -95,7 +95,7 @@ spec:
           {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
             exec:
-              command: ["/usr/local/bin/proxysql_cluster_healthcheck.sh"]
+              command: {{ .Values.proxysql_cluster.healthcheck.command }}
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
@@ -105,7 +105,7 @@ spec:
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             exec:
-              command: ["/usr/local/bin/proxysql_cluster_healthcheck.sh"]
+              command: {{ .Values.proxysql_cluster.healthcheck.command }}
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}

--- a/dysnix/proxysql/templates/statefullset.yaml
+++ b/dysnix/proxysql/templates/statefullset.yaml
@@ -159,25 +159,6 @@ spec:
             {{- toYaml .| nindent 12 }}
           {{- end }}
         {{- end }}
-        {{- if and .Values.proxysql_cluster.enabled .Values.proxysql_cluster.healthcheck.sidecar.enabled }}
-        - name: healthcheck
-          image: {{ .Values.proxysql_cluster.healthcheck.sidecar.image }}
-          command:
-            {{- toYaml .Values.proxysql_cluster.healthcheck.sidecar.command | nindent 14 }}
-          envFrom:
-            - configMapRef:
-                name: '{{ include "proxysql.fullname" . }}-healthcheck'
-            - secretRef:
-                name: '{{ include "proxysql.fullname" . }}-healthcheck'
-          volumeMounts:
-            - name: scripts
-              mountPath: /usr/local/bin/proxysql_cluster_healthcheck.sh
-              subPath: proxysql_cluster_healthcheck.sh
-          {{- with .Values.proxysql_cluster.healthcheck.sidecar.securityContext }}
-          securityContext:
-            {{- toYaml .| nindent 12 }}
-          {{- end }}
-        {{- end }}
       {{- with (default .Values.nodeSelector .Values.proxysql_cluster.core.statefullset.nodeSelector) }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/dysnix/proxysql/templates/statefullset.yaml
+++ b/dysnix/proxysql/templates/statefullset.yaml
@@ -57,6 +57,9 @@ spec:
             {{- if .Values.proxysql_cluster.core.exit_on_error }}
             - "--exit-on-error"
             {{- end }}
+          env:
+            - name: PROXYSQL_IS_CORE_NODE
+              value: "true"
           envFrom:
           {{- if or .Values.readinessProbe.enabled .Values.livenessProbe.enabled }}
             - configMapRef:

--- a/dysnix/proxysql/templates/statefullset.yaml
+++ b/dysnix/proxysql/templates/statefullset.yaml
@@ -74,7 +74,7 @@ spec:
           lifecycle:
             preStop:
               exec:
-                command: ["/bin/sh", "-c", "/usr/local/bin/wait_queries_to_finish.sh > /proc/1/fd/1"]
+                command: ["/bin/sh", "-c", "/usr/local/bin/wait_queries_to_finish.sh"]
           ports:
             - name: proxy
               containerPort: {{ .Values.service.proxyPort }}
@@ -98,7 +98,7 @@ spec:
           {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
             exec:
-              command: {{ .Values.proxysql_cluster.healthcheck.command }}
+              command: {{ .Values.proxysql_cluster.healthcheck.command | toYaml | nindent 16 }}
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
@@ -108,7 +108,7 @@ spec:
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             exec:
-              command: {{ .Values.proxysql_cluster.healthcheck.command }}
+              command: {{ .Values.proxysql_cluster.healthcheck.command | toYaml | nindent 16 }}
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}

--- a/dysnix/proxysql/templates/statefullset.yaml
+++ b/dysnix/proxysql/templates/statefullset.yaml
@@ -75,15 +75,15 @@ spec:
             - name: web
               containerPort: {{ .Values.service.webPort }}
               protocol: TCP
-          {{- if .Values.readinessProbe.enabled }}
-          readinessProbe:
+          {{- if .Values.startupProbe.enabled }}
+          startupProbe:
             exec:
               command: ["bash", "-c", "true <>/dev/tcp/127.0.0.1/{{ .Values.service.proxyPort }}"]
-            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.readinessProbe.successThreshold }}
-            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+            initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.startupProbe.successThreshold }}
+            failureThreshold: {{ .Values.startupProbe.failureThreshold }}
           {{- end }}
           resources:
             {{- toYaml (default .Values.resources .Values.proxysql_cluster.core.statefullset.resources) | nindent 12 }}

--- a/dysnix/proxysql/templates/statefullset.yaml
+++ b/dysnix/proxysql/templates/statefullset.yaml
@@ -57,6 +57,13 @@ spec:
             {{- if .Values.proxysql_cluster.core.exit_on_error }}
             - "--exit-on-error"
             {{- end }}
+          envFrom:
+          {{- if or .Values.readinessProbe.enabled .Values.livenessProbe.enabled }}
+            - configMapRef:
+                name: '{{ include "proxysql.fullname" . }}-healthcheck'
+            - secretRef:
+                name: '{{ include "proxysql.fullname" . }}-healthcheck'
+          {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: {{ template "proxysql.image" . }}

--- a/dysnix/proxysql/values.yaml
+++ b/dysnix/proxysql/values.yaml
@@ -368,8 +368,8 @@ proxysql_cluster:
 
   healthcheck:
     # This is the healtcheck script executed by the k8s probes
-    psql_user: null # If not set use `.mysql_variables.monitor_username`
-    psql_pass: null # If not set use `.mysql_variables.monitor_password`
+    psql_user: null  # If not set use `.mysql_variables.monitor_username`
+    psql_pass: null  # If not set use `.mysql_variables.monitor_password`
     psql_host: "127.0.0.1"  # The listening core host/pod. NOTE: User 'monitor' can only connect locally
     psql_host_port: null  # The admin port. If not set use `.service.adminPort`
 

--- a/dysnix/proxysql/values.yaml
+++ b/dysnix/proxysql/values.yaml
@@ -129,15 +129,13 @@ podDisruptionBudget:
   minAvailable: 1
   # maxUnavailable: 1
 
-readinessProbe:
-  enabled: true
-  initialDelaySeconds: 5
-  ##
-  ## Default Kubernetes values
+startupProbe:
+  enabled: false
+  initialDelaySeconds: 0
   periodSeconds: 10
   timeoutSeconds: 1
-  successThreshold: 1
   failureThreshold: 3
+  successThreshold: 1
 
 # Enable SSL communication with the backend MySQL servers
 ssl:

--- a/dysnix/proxysql/values.yaml
+++ b/dysnix/proxysql/values.yaml
@@ -345,12 +345,6 @@ proxysql_cluster:
   #   until the version/checksum is not 0.
   job:
 
-    image:
-      registry: docker.io
-      repository: mysql
-      tag: "8"
-      pullPolicy: IfNotPresent
-
     enabled: true
 
     # Retry 3 times until failed
@@ -383,8 +377,7 @@ proxysql_cluster:
     kill_if_healthcheck_failed: true  # Kill proxysql daemon if the healthcheck fails the test
     verbose: false
 
-    command:
-      - /usr/local/bin/proxysql_cluster_healthcheck.sh
+    command: ["/bin/sh", "-c", "/usr/local/bin/proxysql_cluster_healthcheck.sh"]
 
 # Enable debugging container along the proxysql instance
 #   It may be usefull to access the proxysql admin interface locally to debug issues

--- a/dysnix/proxysql/values.yaml
+++ b/dysnix/proxysql/values.yaml
@@ -132,22 +132,22 @@ podDisruptionBudget:
 startupProbe:
   enabled: false
   initialDelaySeconds: 5
-  periodSeconds: 10
+  periodSeconds: 3
   timeoutSeconds: 1
-  failureThreshold: 3
+  failureThreshold: 10
   successThreshold: 1
 
 readinessProbe:
   enabled: false
-  initialDelaySeconds: 20
+  initialDelaySeconds: 0
   periodSeconds: 10
   timeoutSeconds: 5
-  failureThreshold: 3
+  failureThreshold: 60
   successThreshold: 1
 
 livenessProbe:
   enabled: false
-  initialDelaySeconds: 15
+  initialDelaySeconds: 5
   periodSeconds: 10
   timeoutSeconds: 5
   failureThreshold: 3
@@ -383,6 +383,7 @@ proxysql_cluster:
 
     diff_check_limit: 10  # How many diff_check errors are tolerated before the healthcheck fails
     kill_if_healthcheck_failed: true  # Kill proxysql daemon if the healthcheck fails the test
+    verbose: false
 
     command:
       - /usr/local/bin/proxysql_cluster_healthcheck.sh

--- a/dysnix/proxysql/values.yaml
+++ b/dysnix/proxysql/values.yaml
@@ -357,7 +357,7 @@ proxysql_cluster:
     backoffLimit: 3
 
     # delete the job resource after given seconds
-    ttlSecondsAfterFinished: 3600
+    ttlSecondsAfterFinished: 86400
 
     nodeSelector: {}
     tolerations: []

--- a/dysnix/proxysql/values.yaml
+++ b/dysnix/proxysql/values.yaml
@@ -131,7 +131,7 @@ podDisruptionBudget:
 
 startupProbe:
   enabled: false
-  initialDelaySeconds: 0
+  initialDelaySeconds: 5
   periodSeconds: 10
   timeoutSeconds: 1
   failureThreshold: 3
@@ -139,7 +139,7 @@ startupProbe:
 
 readinessProbe:
   enabled: false
-  initialDelaySeconds: 10
+  initialDelaySeconds: 20
   periodSeconds: 10
   timeoutSeconds: 5
   failureThreshold: 3

--- a/dysnix/proxysql/values.yaml
+++ b/dysnix/proxysql/values.yaml
@@ -2,8 +2,6 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-replicas: 1
-
 image:
   registry: docker.io
   repository: proxysql/proxysql

--- a/dysnix/proxysql/values.yaml
+++ b/dysnix/proxysql/values.yaml
@@ -137,6 +137,22 @@ startupProbe:
   failureThreshold: 3
   successThreshold: 1
 
+readinessProbe:
+  enabled: false
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+  successThreshold: 1
+
+livenessProbe:
+  enabled: false
+  initialDelaySeconds: 15
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+  successThreshold: 1
+
 # Enable SSL communication with the backend MySQL servers
 ssl:
   ## When a cert and a key or fromSecret are provided use_ssl is be enabled automaticaly (in mysql_servers items)

--- a/dysnix/proxysql/values.yaml
+++ b/dysnix/proxysql/values.yaml
@@ -375,23 +375,17 @@ proxysql_cluster:
     #    memory: 128Mi
 
   healthcheck:
-    sidecar:
-      # inject a healthcheck sidecar container to all proxysql clustering Pods
-      enabled: false
-      image: mysql:debian
-      command:
-        - /usr/local/bin/proxysql_cluster_healthcheck.sh
-      config:
-        psql_user: monitor
-        psql_pass: monitor
-        psql_host: 127.0.0.1  # The listening core host/pod
-        psql_host_port: 6032  # The admin port
+    # This is the healtcheck script executed by the k8s probes
+    psql_user: null # If not set use `.mysql_variables.monitor_username`
+    psql_pass: null # If not set use `.mysql_variables.monitor_password`
+    psql_host: "127.0.0.1"  # The listening core host/pod. NOTE: User 'monitor' can only connect locally
+    psql_host_port: null  # The admin port. If not set use `.service.adminPort`
 
-        diff_check_limit: 10  # How many diff_check errors are tolerated before the healthcheck fails
-        kill_if_healthcheck_failed: true  # Kill proxysql daemon if the healthcheck fails the test
-      securityContext:
-        runAsUser: 999
-        runAsGroup: 999
+    diff_check_limit: 10  # How many diff_check errors are tolerated before the healthcheck fails
+    kill_if_healthcheck_failed: true  # Kill proxysql daemon if the healthcheck fails the test
+
+    command:
+      - /usr/local/bin/proxysql_cluster_healthcheck.sh
 
 # Enable debugging container along the proxysql instance
 #   It may be usefull to access the proxysql admin interface locally to debug issues

--- a/dysnix/proxysql/values.yaml
+++ b/dysnix/proxysql/values.yaml
@@ -5,7 +5,7 @@
 image:
   registry: docker.io
   repository: proxysql/proxysql
-  tag: "2.4.4"
+  tag: null
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
*  Improve and clean up health check scripts
* Add startup, readiness and liveness probes to work accordingly to k8s docs
* Remove not needed healthcheck container (the proxysql docker image has now the necessary mysql/mariadb clients for the checks)
* Rework init job