### PR TITLE
[bsc] speedup init-from-gcs when a source snapshot is pruned

### DIFF
--- a/dysnix/bsc/Chart.yaml
+++ b/dysnix/bsc/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: bsc
 description: Binance Smart Chain chart for Kubernetes
-version: 0.6.44
-appVersion: 1.4.10
+version: 0.6.45
+appVersion: 1.4.11
 
 keywords:
   - geth

--- a/dysnix/bsc/values.yaml
+++ b/dysnix/bsc/values.yaml
@@ -153,6 +153,7 @@ bsc:
     baseUrlOverride: ""                   # "bucket/path/to/dir"
     fullResyncOnSrcUpdate: false
     maxUsedSpacePercent: 93               # percents
+    boostStateCopyWorkers: 800
   syncToGCS:
     enabled: false
     image: peakcom/s5cmd:v2.2.2


### PR DESCRIPTION
We may speed things up using more workers for s5cmd to copy chain state alone