### PR TITLE
[gcp-local-ssd-raid] fix init script crash on subsequent restarts

### DIFF
--- a/dysnix/gcp-local-ssd-raid/Chart.yaml
+++ b/dysnix/gcp-local-ssd-raid/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: gcp-local-ssd-raid
 description: A Helm chart for Kubernetes
-version: 0.1.5
+version: 0.1.6
 appVersion: "0.1.0"
 
 keywords:

--- a/dysnix/gcp-local-ssd-raid/templates/daemonset.yaml
+++ b/dysnix/gcp-local-ssd-raid/templates/daemonset.yaml
@@ -135,8 +135,8 @@ spec:
                   if ! test -e $raid_dev ; then
                     echo "$devs" | xargs /sbin/mdadm --create $raid_dev --level=0 --raid-devices=$(echo "$devs" | wc -l)
                     sudo mkfs.ext4 {{ .Values.localSsd.mkfsOpts }} -F $raid_dev
-                    new_dev=$raid_dev
                   fi
+                  new_dev=$raid_dev
                 else
                   if ! echo "$pvs" | grep volume_all_ssds ; then
                     echo "$devs" | xargs /sbin/pvcreate
@@ -153,7 +153,9 @@ spec:
                   new_dev=/dev/volume_all_ssds/logical_all_ssds
                 fi
 
-                if ! uuid=$(blkid -s UUID -o value $new_dev) ; then
+                uuid=$(blkid -s UUID -o value $new_dev)
+
+                if test -z "$uuid" ; then
                   mkfs.ext4 {{ .Values.localSsd.mkfsOpts }} $new_dev
                   uuid=$(blkid -s UUID -o value $new_dev)
                 fi
@@ -168,7 +170,11 @@ spec:
                 if ! grep "$uuid" /etc/fstab ; then
                   echo "UUID=$uuid $mnt_dir ext4 $mnt_opts" >> /etc/fstab
                 fi
-                mount -U "$uuid" -t ext4 --target "$mnt_dir" --options "$mnt_opts"
+
+                if ! findmnt -n -a -l --nofsroot | grep "$mnt_dir" ; then
+                  mount -U "$uuid" -t ext4 --target "$mnt_dir" --options "$mnt_opts"
+                fi
+
                 chmod a+w "$mnt_dir"
       containers:
         - image: "quay.io/external_storage/local-volume-provisioner:v2.3.2"


### PR DESCRIPTION
When `STARTUP_SCRIPT` has successfully finished for the first time, it will crash with an error on all subsequent pod restarts.
This PR is attempt to fix this behavior.

* fixing check when raid device is already present
* adding check when raid device is already mounted at `$mnt_dir`