### PR TITLE
add loadBalancerClass

### DIFF
--- a/dysnix/pritunl/templates/service.yaml
+++ b/dysnix/pritunl/templates/service.yaml
@@ -15,6 +15,9 @@ spec:
   {{- with .Values.service.loadBalancerIP }}
   loadBalancerIP: {{ . }}
   {{- end }}
+  {{- if eq .Values.service "loadBalancerClass" }}
+  loadBalancerClass: {{ .Values.service.loadBalancerClass }}
+  {{- end }}
   {{- with .Values.service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges:
     {{- toYaml . | nindent 4 }}


### PR DESCRIPTION
Kubernetes v1.24+ introduced support for multiple LoadBalancer implementations via the loadBalancerClass field in Service definitions. This allows clusters to run multiple load balancer controllers (e.g. MetalLB, LoxiLB, Cloud provider LBs) and explicitly target a specific one.

✅ Why this change is needed

Currently, the Service does not specify loadBalancerClass. In clusters with more than one load balancer controller installed, this causes:
	•	Unpredictable behavior, as multiple controllers may compete to provision the same service.
	•	Failure to provision when controllers ignore services without matching class.
	•	Incompatibility with certain CNI/LB solutions that require this field (e.g. LoxiLB, Cilium LB, etc.).

By explicitly setting:
loadBalancerClass: loxilb.io/loxilb
We ensure that the service is only handled by the intended load balancer controller.

🧪 Tested

Tested on Kubernetes v1.28 with LoxiLB as the active controller. Service provisioned successfully and IPs were assigned as expected.

⸻
