### PR TITLE
extend proxy-core kubernetes service

### DIFF
--- a/dysnix/proxysql/Chart.yaml
+++ b/dysnix/proxysql/Chart.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: v1
-appVersion: "2.5.5"
+appVersion: "2.5.6"
 description: ProxySQL Helm chart for Kubernetes
 name: proxysql
 version: 0.11.2

--- a/dysnix/proxysql/templates/service.yaml
+++ b/dysnix/proxysql/templates/service.yaml
@@ -70,6 +70,12 @@ metadata:
     {{- end }}
 spec:
   ports:
+    - name: proxy
+      port: {{ .Values.service.proxyPort }}
+      targetPort: proxy
+      {{- if .Values.service.proxyNodePort }}
+      nodePort: {{ .Values.service.proxyNodePort }}
+      {{- end }}
     - name: admin
       port: {{ .Values.service.adminPort }}
       targetPort: admin


### PR DESCRIPTION
Bug description:
When you disable the statless proxy instance and enable the core one in the values file, the generated service will not route traffic to the proxy port(6033) in proxy-core pod.

This pull request adds proxy port to proxy-core service, which solves the mentioned issue.