### PR TITLE
feat(app): add HTTPRoute and SecurityPolicy support

### DIFF
--- a/dysnix/app/Chart.yaml
+++ b/dysnix/app/Chart.yaml
@@ -3,7 +3,7 @@ name: app
 description: Generic application Helm chart
 home: https://github.com/dysnix/charts/tree/main/dysnix/app
 icon: https://dysnix.com/images/logo.svg
-version: 0.99.21
+version: 0.99.22
 sources:
   - https://github.com/dysnix/charts
 keywords:

--- a/dysnix/app/templates/_resources.tpl
+++ b/dysnix/app/templates/_resources.tpl
@@ -103,3 +103,11 @@ Usage
 {{- define "app.vpa" -}}
   {{- include "app.resources.include" (dict "resource" "vpa" | merge .) -}}
 {{- end -}}
+
+{{- define "app.httproute" -}}
+  {{- include "app.resources.include" (dict "resource" "httproute" | merge .) -}}
+{{- end -}}
+
+{{- define "app.securitypolicy" -}}
+  {{- include "app.resources.include" (dict "resource" "securitypolicy" | merge .) -}}
+{{- end -}}

--- a/dysnix/app/templates/httproute.yaml
+++ b/dysnix/app/templates/httproute.yaml
@@ -1,0 +1,62 @@
+{{/* vim: set filetype=helm: */}}
+{{- define "app.resources.httproute" -}}
+{{- if .Values.httpRoute.enabled }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "app.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels:
+    {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if or .Values.httpRoute.annotations .Values.commonAnnotations }}
+  annotations:
+    {{- if .Values.httpRoute.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.httpRoute.annotations "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+spec:
+  {{- if .Values.httpRoute.parentRefs }}
+  parentRefs:
+    {{- include "common.tplvalues.render" (dict "value" .Values.httpRoute.parentRefs "context" $) | nindent 4 }}
+  {{- end }}
+  {{- if .Values.httpRoute.hostnames }}
+  hostnames:
+    {{- range .Values.httpRoute.hostnames }}
+    - {{ tpl . $ | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- if .Values.httpRoute.rules }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.httpRoute.rules "context" $) | nindent 4 }}
+    {{- else }}
+    {{- $port := .Values.httpRoute.servicePort -}}
+    {{- if and (not $port) .Values.service.ports (eq (len (keys .Values.service.ports)) 1) }}
+      {{- $portName := keys .Values.service.ports | first -}}
+      {{- $port = get (get .Values.service.ports $portName) "port" }}
+    {{- else if and $port (kindIs "string" $port) (get .Values.service.ports $port) }}
+      {{- $port = get (get .Values.service.ports $port) "port" }}
+    {{- end }}
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ .Values.httpRoute.serviceName | default (include "app.fullname" .) }}
+          port: {{ required "httpRoute.servicePort is required when httpRoute.rules is not set" $port | int }}
+    {{- end }}
+{{- end }}
+{{- end -}}
+
+{{- if eq "direct" (include "app.chart.mode" .) -}}
+  {{- range $_, $component := concat (list "") $.Values.app.components -}}
+    {{- $values := ternary $.Values (get $.Values "component") (eq $component "") | default dict -}}
+    {{- include "app.httproute" (dict "component" $component "values" $values "top" $) -}}
+  {{- end -}}
+{{- end -}}

--- a/dysnix/app/templates/security-policy.yaml
+++ b/dysnix/app/templates/security-policy.yaml
@@ -1,0 +1,43 @@
+{{/* vim: set filetype=helm: */}}
+{{- define "app.resources.securitypolicy" -}}
+{{- if and .Values.securityPolicy.enabled (not .Values.securityPolicy.targetRefs) (not .Values.httpRoute.enabled) }}
+{{- fail "securityPolicy requires httpRoute.enabled=true when securityPolicy.targetRefs is not set" }}
+{{- end }}
+{{- if .Values.securityPolicy.enabled }}
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: {{ include "app.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels:
+    {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations:
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  targetRefs:
+    {{- if .Values.securityPolicy.targetRefs }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.securityPolicy.targetRefs "context" $) | nindent 4 }}
+    {{- else }}
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: {{ include "app.fullname" . }}
+    {{- end }}
+  {{- if .Values.securityPolicy.authorization }}
+  authorization:
+    {{- include "common.tplvalues.render" (dict "value" .Values.securityPolicy.authorization "context" $) | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end -}}
+
+{{- if eq "direct" (include "app.chart.mode" .) -}}
+  {{- range $_, $component := concat (list "") $.Values.app.components -}}
+    {{- $values := ternary $.Values (get $.Values "component") (eq $component "") | default dict -}}
+    {{- include "app.securitypolicy" (dict "component" $component "values" $values "top" $) -}}
+  {{- end -}}
+{{- end -}}

--- a/dysnix/app/values.yaml
+++ b/dysnix/app/values.yaml
@@ -738,6 +738,77 @@ ingress:
   ##
   extraRules: []
 
+## HTTPRoute parameters (Gateway API)
+## ref: https://gateway-api.sigs.k8s.io/api-types/httproute/
+##
+httpRoute:
+  ## @param httpRoute.enabled Enable HTTPRoute record generation
+  ##
+  enabled: false
+  ## @param httpRoute.annotations Additional annotations for the HTTPRoute
+  ##
+  annotations: {}
+  ## @param httpRoute.parentRefs Parent gateway references
+  ## e.g:
+  ## parentRefs:
+  ##   - name: envoy-metallb
+  ##     namespace: envoy-ingress
+  ##     sectionName: https
+  ##
+  parentRefs: []
+  ## @param httpRoute.hostnames List of hostnames for the HTTPRoute
+  ## e.g:
+  ## hostnames:
+  ##   - app.example.com
+  ##
+  hostnames: []
+  ## @param httpRoute.servicePort Service port for the default backend rule (required when rules is not set)
+  ##
+  servicePort: ""
+  ## @param httpRoute.serviceName Override the backend service name. Defaults to the app's own service (app.fullname)
+  ##
+  serviceName: ""
+  ## @param httpRoute.rules Custom HTTPRoute rules. If empty, a default rule routing to the app service is generated
+  ## e.g:
+  ## rules:
+  ##   - matches:
+  ##       - path:
+  ##           type: PathPrefix
+  ##           value: /
+  ##     backendRefs:
+  ##       - name: my-service
+  ##         port: 8080
+  ##
+  rules: []
+
+## SecurityPolicy parameters (Envoy Gateway)
+## ref: https://gateway.envoyproxy.io/docs/api/extension_types/#securitypolicy
+##
+securityPolicy:
+  ## @param securityPolicy.enabled Enable SecurityPolicy generation. Requires httpRoute.enabled: true unless securityPolicy.targetRefs is set
+  ##
+  enabled: false
+  ## @param securityPolicy.targetRefs Custom target references. Defaults to the app's HTTPRoute
+  ## e.g:
+  ## targetRefs:
+  ##   - group: gateway.networking.k8s.io
+  ##     kind: HTTPRoute
+  ##     name: my-route
+  ##
+  targetRefs: []
+  ## @param securityPolicy.authorization Authorization configuration
+  ## e.g:
+  ## authorization:
+  ##   defaultAction: Deny
+  ##   rules:
+  ##     - name: allow-whitelist
+  ##       action: Allow
+  ##       principal:
+  ##         clientCIDRs:
+  ##           - "1.2.3.4/32"
+  ##
+  authorization: {}
+
 ## @section Persistence Parameters
 ##
 


### PR DESCRIPTION
  - Add httproute.yaml template with named port resolution and auto-detection
  - Add security-policy.yaml template targeting the app's HTTPRoute by default
  - Add app.httproute and app.securitypolicy wrappers in _resources.tpl
  - Add httpRoute and securityPolicy sections to values.yaml
  - Bump chart version to 0.99.22